### PR TITLE
docs: add Ticket Panels (v5.2) documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,20 @@ What's new in Server Assistant. Internal-only updates (CI, dependency bumps, hos
 
 ---
 
+## v5.2 — Ticket Panels
+
+Private in-server support tickets — no DMs, no leaving your server, no messy threads.
+
+### Added
+- **🎫 Ticket Panels.** Admins run `/tickets setup` to post a panel embed with a **Create Ticket** button in any channel. Members click it to fill a short intake form; the bot creates a private `ticket-NNNN-username` channel, notifies the support role, and drops in a **Close Ticket** button. On close, a full `.txt` transcript is posted to the configured channel and the ticket channel is deleted.
+- **Free tier:** one-question intake form, private ticket channels, transcript on close, editable panel text.
+- **Premium tier:** up to 4 custom intake form questions (`/tickets questions`), custom welcome and close messages (`/tickets panel`), and the ability to add users to an open ticket mid-conversation (`/tickets add @user`).
+- **Persistent panels** — the Create Ticket button survives bot restarts.
+- **Per-ticket privacy** — each ticket channel is visible only to the opener, the configured support role, and admins.
+- **Storage** in `tickets.json` alongside the other per-guild JSON stores; no extra setup required.
+
+---
+
 ## v5.1 — Complete audit trail & tamper protection
 
 Oversight you can trust. Server Assistant now records **every** moderation action — not just the ones run through the bot — and keeps them somewhere staff can't touch.

--- a/commands.md
+++ b/commands.md
@@ -22,7 +22,7 @@ Server Assistant supports **three interaction modes**. Most commands are availab
 Targeting users supports `@mention`, plain-text username (e.g. `mute jen`), or numeric Discord user ID.
 
 | Command | Description | Example |
-|---------|-------------|---------|
+|---------|-------------|-------|
 | `ban @user [reason]` | Ban a user | `ban @spammer raid` |
 | `kick @user [reason]` | Kick a user | `kick username spam` |
 | `softban @user` | Ban + immediate unban — clears recent messages, lets user rejoin | `softban @user` |
@@ -168,6 +168,22 @@ The `undo` command reverses your most recent reversible action.
 
 ---
 
+## 🎫 Ticket Panels
+
+Set up a persistent support-ticket panel in any public channel. Members click **Create Ticket** to open a private channel with your support team.
+
+| Command | Description | Who |
+|---------|-------------|-----|
+| `/tickets setup` | Configure the ticket system and post a panel embed | Admin / Owner |
+| `/tickets close [reason]` | Close the ticket channel you're currently in | Ticket owner, support role, or anyone with Manage Channels |
+| `/tickets panel` | Edit the panel's title/description, or (Premium) set custom in-ticket messages | Admin / Owner |
+| `/tickets questions` | *(Premium)* Define up to 4 custom intake form questions | Admin / Owner |
+| `/tickets add @user` | *(Premium)* Add a user to the current open ticket | Admin / Owner |
+
+See **[Features → Ticket Panels]({{ site.url }}{{ site.baseurl }}/features/#-ticket-panels)** for the full setup walkthrough and free vs Premium breakdown.
+
+---
+
 ## 🖱️ Right-click context menus
 
 Right-click any user or message → hover **Apps ▸ Server Assistant**:
@@ -188,7 +204,7 @@ Right-click any user or message → hover **Apps ▸ Server Assistant**:
 Type `/` anywhere to see autocomplete:
 
 | Slash command | What it does |
-|--------------|--------------|
+|--------------|----------------|
 | `/setup` | Initial config wizard (owner only) |
 | `/settings` | Open customisation hub |
 | `/automod` | Configure auto-moderation |
@@ -220,6 +236,11 @@ Type `/` anywhere to see autocomplete:
 | `/premium` | See your server's premium status + what's included |
 | `/vote` | Vote for the bot (Top.gg + Discord Bot List) |
 | `/invite` | Get the bot's invite URL |
+| `/tickets setup` | Configure ticket system + post panel in a channel |
+| `/tickets close [reason]` | Close the ticket channel you're in |
+| `/tickets panel` | Edit panel title/description or (Premium) custom messages |
+| `/tickets questions` | *(Premium)* Set up to 4 custom intake form questions |
+| `/tickets add @user` | *(Premium)* Add a user to an open ticket |
 
 Most slash command responses are **only visible to you** by default for sensitive operations.
 
@@ -260,6 +281,9 @@ Each role you configure in `/settings → Role Tiers` has **capabilities** (what
 <tr><td>/imagine, /vote, /premium, /invite</td><td class="perm-y">✓</td><td class="perm-y">✓</td><td class="perm-y">✓</td></tr>
 <tr><td>/settings</td><td class="perm-n">—</td><td class="perm-y">✓</td><td class="perm-y">✓</td></tr>
 <tr><td>/setup, /ai-config</td><td class="perm-n">—</td><td class="perm-n">—</td><td class="perm-y">✓</td></tr>
+<tr><td>/tickets setup, /tickets panel, /tickets questions</td><td class="perm-n">—</td><td class="perm-y">✓</td><td class="perm-y">✓</td></tr>
+<tr><td>/tickets close</td><td class="perm-y">✓</td><td class="perm-y">✓</td><td class="perm-y">✓</td></tr>
+<tr><td>/tickets add (Premium)</td><td class="perm-n">—</td><td class="perm-y">✓</td><td class="perm-y">✓</td></tr>
 </tbody>
 </table>
 
@@ -304,5 +328,5 @@ You can customise any of this in `/settings → Role Tiers` — grant Mods `/unb
 ## What's next?
 
 - [FAQ]({{ site.url }}{{ site.baseurl }}/faq/) for common questions
-- [Features]({{ site.url }}{{ site.baseurl }}/features/) for deep dives on AutoMod, verification gate, AI features
+- [Features]({{ site.url }}{{ site.baseurl }}/features/) for deep dives on AutoMod, verification gate, AI features, and Ticket Panels
 - [Setup]({{ site.url }}{{ site.baseurl }}/setup/) if you haven't run `/setup` yet

--- a/features.md
+++ b/features.md
@@ -215,6 +215,52 @@ Verbosity: **All / Dangerous-only / Errors-only** (`/settings → Behavior → L
 
 ---
 
+## 🎫 Ticket Panels <span class="tier-badge tier-free">FREE</span> <span class="tier-badge tier-premium">PREMIUM</span>
+
+Give your members a private, structured way to reach staff without leaving your server. An admin posts a panel in any public channel; members click **Create Ticket** to open a dedicated private channel with your support team.
+
+**How the flow works:**
+
+1. Admin runs `/tickets setup` — picks the panel channel, ticket category, support role, and (optionally) a transcript channel.
+2. The bot posts a styled embed with a persistent **Create Ticket** button.
+3. A member clicks the button, fills a short intake form (a Discord modal), and the bot creates a private `ticket-0001-username` channel — visible only to them, the support role, and admins.
+4. The ticket's opening message shows the intake answers, pings the support role, and includes a **Close Ticket** button.
+5. On close, the bot saves a `.txt` transcript and posts it to the transcript channel, then deletes the ticket channel after 5 seconds.
+
+<div class="f-grid">
+  <div class="f-card">
+    <h4>Free tier <span class="tier-badge tier-free">FREE</span></h4>
+    <ul>
+      <li>Panel embed with one intake question (<em>"Briefly describe your issue"</em>)</li>
+      <li>Private ticket channels with support-role and admin access</li>
+      <li>Close button in every ticket + <code>/tickets close [reason]</code></li>
+      <li>Plain-text <code>.txt</code> transcript posted to the transcript channel on close</li>
+      <li>Edit panel title and description via <code>/tickets panel</code></li>
+    </ul>
+  </div>
+  <div class="f-card">
+    <h4>Premium tier <span class="tier-badge tier-premium">PREMIUM</span></h4>
+    <ul>
+      <li><strong>Up to 4 custom intake questions</strong> — <code>/tickets questions q1: … q2: … q3: … q4: …</code></li>
+      <li><strong>Custom welcome message</strong> — set via <code>/tickets panel welcome_message: …</code></li>
+      <li><strong>Custom close message</strong> — set via <code>/tickets panel close_message: …</code></li>
+      <li><strong>Add users mid-ticket</strong> — <code>/tickets add @user</code></li>
+    </ul>
+  </div>
+</div>
+
+| Command | Who can use it |
+|---|---|
+| `/tickets setup` | Admin / Owner |
+| `/tickets close [reason]` | Ticket owner, support-role members, anyone with Manage Channels |
+| `/tickets panel` | Admin / Owner |
+| `/tickets questions` | Admin / Owner *(Premium)* |
+| `/tickets add @user` | Admin / Owner *(Premium)* |
+
+> **Note:** The bot needs **Manage Channels** and **Manage Roles** permissions to create private ticket channels and set per-channel access overwrites. Make sure the bot's role sits above the support role in the Discord role hierarchy.
+
+---
+
 ## 🔐 Privacy & Security <span class="tier-badge tier-free">FREE</span>
 
 Your AI keys and other credentials are **encrypted at rest**. Per-server data is isolated. Removing the bot wipes your server's encrypted secrets immediately; the retention rules for warnings, notes, and audit logs are in the **[Privacy Policy]({{ site.url }}{{ site.baseurl }}/privacy/)**.

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ image: /server-assistant-docs/assets/banner.jpeg
   "name": "Server Assistant",
   "applicationCategory": "Discord Bot",
   "operatingSystem": "Discord",
-  "description": "AI Discord moderation and automation bot with Pulse daily server-health digests, AI-assisted moderation reports, customisable AutoMod with custom regex and ReDoS guard, anti-raid detection, DM-button verification gate, and AI image generation.",
+  "description": "AI Discord moderation and automation bot with Pulse daily server-health digests, AI-assisted moderation reports, customisable AutoMod with custom regex and ReDoS guard, anti-raid detection, DM-button verification gate, ticket panels, and AI image generation.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "url": "https://wandweb2.github.io/server-assistant-docs/",
   "image": "https://wandweb2.github.io/server-assistant-docs/assets/banner.jpeg",
@@ -138,6 +138,14 @@ Running a Discord community means staying ahead of raids, keeping staff accounta
     <ul>
       <li>Button-based new-member verification</li>
       <li>Stops most automated raid bots</li>
+    </ul>
+  </div>
+  <div class="feat-card">
+    <h3>🎫 Ticket Panels</h3>
+    <ul>
+      <li>Private support tickets inside your server</li>
+      <li>Intake form, transcripts, persistent panel button</li>
+      <li>Custom questions + messages <small>(premium)</small></li>
     </ul>
   </div>
   <div class="feat-card">

--- a/pricing.md
+++ b/pricing.md
@@ -29,6 +29,7 @@ These never count against any token allowance:
 - **Privacy panel** — `/privacy` to control exactly what the bot reads
 - **Snippets + scheduled reminders**
 - **`/imagine`** via free Pollinations.ai fallback
+- **Ticket Panels (core)** — panel embed, private ticket channels, one intake question, `.txt` transcripts on close, `/tickets close`
 
 ---
 
@@ -57,7 +58,10 @@ These read messages or generate content:
 | **Concierge chat** | — | ✅ | ✅ |
 | **Active Threat Score** | — | ✅ | ✅ |
 | **Unlimited `/imagine`** | — | ✅ | ✅ |
+| **Ticket Panels — premium features** | — | ✅ | ✅ |
 | **All free features** | ✅ | ✅ | ✅ |
+
+**Ticket Panels — premium features** include: up to 4 custom intake form questions, custom welcome and close messages, and `/tickets add @user` to grant mid-ticket access.
 
 ### How Premium trial billing works
 
@@ -95,7 +99,7 @@ No — not immediately. We capture your card at signup but only charge it when y
 </details>
 
 <details><summary>What happens when I run out of free tokens?</summary>
-AI features pause. Core moderation (AutoMod, anti-raid, warnings, slash commands, audit log) keeps working with no change. You'll get a DM — if you're subscribed to Premium, billing starts automatically. If you're on the free tier, you can subscribe or buy a top-up to continue.
+AI features pause. Core moderation (AutoMod, anti-raid, warnings, slash commands, audit log, Ticket Panels) keeps working with no change. You'll get a DM — if you're subscribed to Premium, billing starts automatically. If you're on the free tier, you can subscribe or buy a top-up to continue.
 </details>
 
 <details><summary>What if a single user spams Concierge or Report Message?</summary>
@@ -107,7 +111,7 @@ Yes — `/ai-config` lets you paste your own Anthropic, xAI, or OpenAI key. BYOK
 </details>
 
 <details><summary>What if I cancel Premium?</summary>
-You drop to the free tier. If your 150K lifetime trial was already used, AI features pause until you re-subscribe or buy a top-up. Core moderation never stops.
+You drop to the free tier. If your 150K lifetime trial was already used, AI features pause until you re-subscribe or buy a top-up. Core moderation and basic Ticket Panels never stop.
 </details>
 
 <details><summary>Do prices include tax?</summary>


### PR DESCRIPTION
## Summary\n\n- **features.md** — new `## 🎫 Ticket Panels` section covering the full flow, free vs premium split (2-card grid), per-command permission table, and a setup note about bot permissions required\n- **commands.md** — new `## 🎫 Ticket Panels` section with a 3-column command table; `/tickets` commands added to the slash command quick reference; 3 new rows in the permissions table (setup/panel/questions = Admin+, close = all staff, add = Admin+)\n- **changelog.md** — `## v5.2 — Ticket Panels` entry added at the top with free and premium breakdowns\n- **pricing.md** — `Ticket Panels (core)` added to \"What's always free\"; `Ticket Panels — premium features` row added to the plans comparison table with a clarifying footnote; FAQ answer for \"What happens when I run out of tokens\" updated to mention Ticket Panels stays available\n- **index.md** — 🎫 Ticket Panels card added to the \"What's in the box\" grid; JSON-LD description updated to mention ticket panels\n\n## Test plan\n\n- [ ] Verify `## 🎫 Ticket Panels` section renders correctly on features page with tier badges\n- [ ] Verify ticket commands appear in slash command quick reference table on commands page\n- [ ] Verify permissions table rows for `/tickets` are correct (Admin for setup, Mod+ for close)\n- [ ] Verify v5.2 changelog entry appears at the top of the changelog page\n- [ ] Verify pricing page shows Ticket Panels in both the free list and the plans table\n- [ ] Verify Ticket Panels card appears in the homepage \"What's in the box\" grid\n\nhttps://claude.ai/code/session_01EMPmtF1qwGEufD2ZqhpfUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMPmtF1qwGEufD2ZqhpfUA)_