### PR TITLE
Document /feedback as an alias of /support

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -262,6 +262,7 @@ Type `/` anywhere to see autocomplete:
 | `/premium` | See your server's premium status + what's included |
 | `/vote` | Vote for the bot (Top.gg + Discord Bot List) |
 | `/invite` | Get the bot's invite URL |
+| `/support` *(alias `/feedback`)* | Open a support ticket or send feedback to the dev via DM |
 | `/tickets setup [channel] [support_role] [create_channel]` | Post the ticket panel. Pass `create_channel` to have the bot make a properly-locked channel for you |
 | `/tickets close [reason]` | Close the ticket channel you're in |
 | `/tickets panel` | Edit panel title/description or (Premium) custom messages |

--- a/support.md
+++ b/support.md
@@ -7,7 +7,7 @@ description: How to get help with Server Assistant — use the /support slash co
 
 # 💬 Get Help
 
-The only support channel is the **`/support`** slash command, run from any server that has Server Assistant installed.
+The only support channel is the **`/support`** slash command — also available as **`/feedback`**, which is an exact alias — run from any server that has Server Assistant installed.
 
 ---
 
@@ -19,7 +19,7 @@ In any Discord channel where you can send messages, type:
 /support
 ```
 
-That's it — no message parameter needed. The bot replies privately (ephemeral) with a short info embed and two buttons:
+(or `/feedback` — both open the same ticket flow). That's it — no message parameter needed. The bot replies privately (ephemeral) with a short info embed and two buttons:
 
 - **Create a ticket** — the bot DMs you and waits. Your next DM (within 15 minutes) becomes the ticket. You can include text, screenshots, or both.
 - **Never mind** — closes the prompt. No ticket created.


### PR DESCRIPTION
## Summary

Documents the new `/feedback` alias for `/support` (companion to the bot PR).

- `support.md`: notes `/feedback` is an exact alias, both in the intro and the "open a ticket" step.
- `commands.md`: adds a `/support` *(alias `/feedback`)* row to the slash-command quick reference (it was previously missing from that table).

https://claude.ai/code/session_01QB9RAhjMh6cBCTf93fWXNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB9RAhjMh6cBCTf93fWXNY)_