### PR TITLE
changelog: move version nav to bottom and make it subtle

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,22 +21,13 @@ What's new in Server Assistant. Internal-only updates (CI, dependency bumps, hos
 .doc-sec[open] > summary { margin: 0 -.9rem .35rem; }
 .doc-sec code { color: var(--accent); }
 .doc-sec h3 { font-size: 1rem; margin: .7rem 0 .3rem; }
-.changelog-nav { display: flex; gap: 0.4rem; flex-wrap: wrap; margin: 0.6rem 0 1.2rem; padding: 0.5rem; background: rgba(46,204,113,0.06); border: 1px solid rgba(46,204,113,0.20); border-radius: 10px; }
-.changelog-nav strong { font-size: 0.78rem; color: #2c7ad6; font-weight: 700; padding: 0.35rem 0.6rem 0.35rem 0; align-self: center; }
-.changelog-nav a { display: inline-block; padding: 0.35rem 0.85rem; border-radius: 999px; font-size: 0.85rem; font-weight: 600; text-decoration: none; color: #2c3e50; background: rgba(255,255,255,0.7); border: 1px solid rgba(31,38,135,0.12); transition: all 0.15s; }
-.changelog-nav a:hover { background: #2c7ad6; color: white; border-color: #2c7ad6; text-decoration: none; }
-.changelog-nav a.current { background: #2c7ad6; color: white; border-color: #2c7ad6; }
-.changelog-nav .latest-tag { font-size: 0.65rem; font-weight: 800; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.8; margin-left: 0.3rem; }
+.changelog-nav { display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: baseline; margin: 1.6rem 0 0.4rem; padding-top: 0.85rem; border-top: 1px solid var(--glass-border); font-size: 0.8rem; opacity: 0.7; }
+.changelog-nav strong { font-size: 0.68rem; font-weight: 600; color: var(--ink-soft); text-transform: uppercase; letter-spacing: 0.05em; }
+.changelog-nav a { color: var(--ink-soft); text-decoration: none; border-bottom: 1px dotted var(--ink-soft); padding-bottom: 1px; transition: color 0.15s, border-color 0.15s; }
+.changelog-nav a:hover { color: var(--accent); border-bottom-color: var(--accent); text-decoration: none; }
+.changelog-nav a.current { color: var(--ink); border-bottom-style: solid; }
+.changelog-nav .latest-tag { font-size: 0.58rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.7; margin-left: 0.25rem; }
 </style>
-
-<div class="changelog-nav">
-  <strong>Browse by version</strong>
-  <a href="{{ site.url }}{{ site.baseurl }}/changelog/" class="{% if page.permalink == '/changelog/' %}current{% endif %}">v5.x <span class="latest-tag">latest</span></a>
-  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v4/" class="{% if page.permalink == '/changelog/v4/' %}current{% endif %}">v4.x</a>
-  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v3/" class="{% if page.permalink == '/changelog/v3/' %}current{% endif %}">v3.x</a>
-  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v2/" class="{% if page.permalink == '/changelog/v2/' %}current{% endif %}">v2.x</a>
-  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v1/" class="{% if page.permalink == '/changelog/v1/' %}current{% endif %}">v1.x</a>
-</div>
 
 <details class="doc-sec" markdown="1" open>
 <summary>v5.6.28 — Setup works when staff add the bot</summary>
@@ -635,6 +626,15 @@ The biggest release yet. Premium ships with an honest billing model — subscrib
 
 
 </details>
+
+<div class="changelog-nav">
+  <strong>Browse by version</strong>
+  <a href="{{ site.url }}{{ site.baseurl }}/changelog/" class="{% if page.permalink == '/changelog/' %}current{% endif %}">v5.x <span class="latest-tag">latest</span></a>
+  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v4/" class="{% if page.permalink == '/changelog/v4/' %}current{% endif %}">v4.x</a>
+  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v3/" class="{% if page.permalink == '/changelog/v3/' %}current{% endif %}">v3.x</a>
+  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v2/" class="{% if page.permalink == '/changelog/v2/' %}current{% endif %}">v2.x</a>
+  <a href="{{ site.url }}{{ site.baseurl }}/changelog/v1/" class="{% if page.permalink == '/changelog/v1/' %}current{% endif %}">v1.x</a>
+</div>
 
 ## What's next?
 


### PR DESCRIPTION
Moves the "Browse by version" navigation from the top of the changelog to the **bottom** (below the release list, just above "What's next?"), and restyles it to be visually **subtler than the release entries**.

## Changes

- **Position:** nav now renders at the bottom of the page instead of the top.
- **Style:** dropped the green pill/box treatment. It's now a quiet footer — a thin top-border separator, smaller muted text (`--ink-soft`), dotted underline links that pick up the accent colour on hover, and overall reduced opacity. The bold, bordered release `<details>` cards remain the visual focus of the page.

`<details>` tags still balance (33/33), and there's a single nav block.

https://claude.ai/code/session_01DP4aawE3EA2fbtU6ixir9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP4aawE3EA2fbtU6ixir9Z)_