### PR TITLE
Add Claude×omp build pipeline (orchestrator + contained implementer)

### DIFF
--- a/.omp/skills/sa-jekyll-docs/SKILL.md
+++ b/.omp/skills/sa-jekyll-docs/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: sa-jekyll-docs
+description: Conventions for the Server Assistant documentation site (Jekyll + Minima on GitHub Pages). Use when editing or adding pages, front matter, navigation, or copy in the docs repo.
+---
+
+# Jekyll docs conventions
+
+This is a Jekyll site on the Minima theme, published to GitHub Pages. Content is
+kramdown Markdown; most pages are plain `.md` files at the repo root with pretty
+permalinks (`/:title/`).
+
+- **Front matter**: pages inherit `layout: default` and a default share image
+  via `_config.yml` defaults — you usually only need `title:` (plus any
+  page-specific keys a neighbouring page already uses). Match nearby pages.
+- **Navigation**: the top nav is the curated `header_pages` list in
+  `_config.yml`; deeper pages are reached via the footer. Don't add a page to
+  `header_pages` unless the task says to.
+- **Language**: British English (`lang: en-GB`) — "organise", "behaviour",
+  "licence" (the noun). Keep marketing claims consistent with `features.md` and
+  `pricing.md`.
+- **Build**: if a `Gemfile` is present, validate with `bundle exec jekyll
+  build`. Keep internal links relative and working; don't hardcode the
+  production domain.
+- **Don't publish noise**: non-page files (`OMP.md`, `scripts/`, `.omp/`) are
+  excluded in `_config.yml` — keep them excluded so they never render as pages.

--- a/.omp/skills/sa-orientation/SKILL.md
+++ b/.omp/skills/sa-orientation/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: sa-orientation
+description: Read this first on any task — you are new to this codebase. How to get your bearings before changing anything: read the README and the module you're touching, establish a green baseline, and confirm scope. Always orient before implementing.
+---
+
+# Get your bearings first
+
+You are a capable implementer but **new to this project** — you have no memory
+of it between runs. Before you change anything, orient yourself. Rushing in
+without this is the most common rookie mistake.
+
+1. **Read the lay of the land.** Read `README.md`, then the entry-point module
+   and any file the spec names. Skim neighbouring files to learn the
+   conventions actually in use — don't invent your own.
+2. **Establish a green baseline.** Run the test suite once *before* editing
+   (e.g. `pytest -q`, or `bundle exec jekyll build` for docs) so you know what
+   "working" looks like and can tell what your change affected.
+3. **Confirm scope.** Re-read the spec's acceptance criteria and the in/out-of
+   scope notes. If something is ambiguous or the spec seems to conflict with
+   what the code does, ask the foreman **before** writing code — a short
+   question now beats a wrong implementation later.
+4. **Then implement** — in small, reviewable steps, matching the surrounding
+   style.
+
+You are being coached. It is expected that early work comes back with
+corrections; fix your own misses honestly rather than hiding them. Read the
+other `sa-*` skills (`sa-stay-in-box`, `sa-self-verify`, and this repo's
+conventions skill) — they are your standing instructions.

--- a/.omp/skills/sa-self-verify/SKILL.md
+++ b/.omp/skills/sa-self-verify/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: sa-self-verify
+description: Use after implementing any change and before yielding back to the orchestrator. Runs the repo's tests and linters, re-reads the diff against the spec's acceptance criteria, and reports pass/fail with residual risks. Always run before considering an implementation task complete.
+---
+
+# Self-verify before yielding
+
+You are the implementer in a two-agent pipeline. The orchestrating Claude
+session handed you a spec with explicit **acceptance criteria** and owns review
+and merge. Your job is to hand back work that is already green.
+
+Before you yield:
+
+1. **Run the checks the spec named.** If it listed exact tests/commands, run
+   those. Otherwise discover and run the repo's suite:
+   - Python repos: `pytest -q` (plus any `requirements-dev.txt` tooling such as
+     `ruff` / `flake8` / `black --check` if the repo configures it).
+   - Jekyll docs: `bundle exec jekyll build` if a `Gemfile` is present;
+     otherwise validate front matter and internal links.
+2. **Re-read your own diff** (`git diff`) against every acceptance criterion.
+   Confirm each is met and that nothing out of scope was touched.
+3. **Report, don't guess.** End with a short summary:
+   - what changed (files + why),
+   - the exact check commands you ran and their results,
+   - any criterion you could NOT satisfy, and why,
+   - residual risks the reviewer should look at.
+
+Never claim success on a check you did not actually run. If a check fails and
+you cannot fix it within scope, stop and report the failure verbatim — do not
+paper over it.

--- a/.omp/skills/sa-stay-in-box/SKILL.md
+++ b/.omp/skills/sa-stay-in-box/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: sa-stay-in-box
+description: Always-on guardrail for the omp implementer. Defines the boundary between work you may do autonomously (anything inside the local working tree) and actions reserved for the orchestrator (push, pull requests, merges, deploys, external services). Consult whenever a task seems to require leaving the working tree.
+---
+
+# Stay inside the box
+
+You implement **inside the local working tree only**. Another agent (the
+orchestrating Claude session) owns everything that crosses the boundary.
+
+You MAY, autonomously:
+
+- read, edit, and write files anywhere in this repository;
+- run builds, tests, linters, and local scripts;
+- create local commits on the current branch;
+- spawn as many subagents as the task benefits from.
+
+You MUST NOT, ever:
+
+- `git push`, or open / modify / merge pull requests;
+- deploy, publish, or run release / `deploy-*.sh` scripts;
+- call external services, send mail, or make network calls beyond what a local
+  build or test legitimately needs;
+- modify git remotes, credentials, or CI configuration to gain reach.
+
+If a task appears to require any of the above, do **not** attempt a workaround.
+Finish the part you can do locally, commit it, and state clearly in your final
+report what boundary-crossing step remains, so the orchestrator can do it and
+gate it for merge safety.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,31 @@ sync it first by merging `origin/main` into the branch and re-applying the
 change — never force-push.
 
 _To revoke this, delete this section._
+
+## Multi-agent build pipeline — Claude orchestrates, omp implements
+
+For substantial implementation work this repo uses a two-agent model: **you
+(Claude Code) plan and guard; `omp` (the oh-my-pi coding agent) implements.**
+Full operating model and rationale: [`OMP.md`](OMP.md).
+
+The short version:
+
+1. **Turn the user's request into a spec** with explicit, testable acceptance
+   criteria (the exact tests/commands that must pass).
+2. **Delegate implementation to `omp`** via `scripts/omp-build "<spec>"`. `omp`
+   runs autonomously but is contained to the local working tree (auto-approved,
+   unlimited subagents, but **no** github/ssh/browser/web and **no**
+   push/PR/merge). Iterate with it in a bounded Q&A loop.
+3. **You cross the boundary, never `omp`.** You push the branch and open the PR;
+   `omp` only commits locally.
+4. **Review independently** — the omp-authored diff against the user's original
+   intent and the acceptance criteria.
+5. **Merge = auto-ship guardrails + your validation.** The auto-ship
+   authorization above still applies, but for any `omp`-authored change your
+   independent review is an additional hard gate: squash-merge only when CI is
+   green, there are no unresolved human reviews, **and** your review is clean.
+   If your review flags anything material, do not merge — report and wait.
+
+Use the pipeline for substantial multi-file work; small changes you make
+directly. `omp` is only ever invoked through `scripts/omp-build`, which keeps it
+boundary-contained — never grant it push, PR, or merge ability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,20 +27,27 @@ _To revoke this, delete this section._
 
 ## Multi-agent build pipeline — Claude orchestrates, omp implements
 
-For substantial implementation work this repo uses a two-agent model: **you
-(Claude Code) plan and guard; `omp` (the oh-my-pi coding agent) implements.**
-Full operating model and rationale: [`OMP.md`](OMP.md).
+For substantial implementation work this repo uses a **three-tier** model: the
+**Director** (the human + you) sets intent and guards; a **Foreman** (a Claude
+subagent you spawn) manages the worker; the **Worker** (`omp`, the oh-my-pi
+coding agent) implements. You and the human operate at the director level — you
+do not babysit `omp` directly. Treat `omp` as a **capable greenhorn**: fast, but
+new to this project and in need of onboarding. Full operating model and
+rationale: [`OMP.md`](OMP.md).
 
 The short version:
 
 1. **Turn the user's request into a spec** with explicit, testable acceptance
-   criteria (the exact tests/commands that must pass).
-2. **Delegate implementation to `omp`** via `scripts/omp-build "<spec>"`. `omp`
-   runs autonomously but is contained to the local working tree (auto-approved,
-   unlimited subagents, but **no** github/ssh/browser/web and **no**
-   push/PR/merge). Iterate with it in a bounded Q&A loop.
-3. **You cross the boundary, never `omp`.** You push the branch and open the PR;
-   `omp` only commits locally.
+   criteria (the exact tests/commands that must pass) — generous enough for a
+   greenhorn to follow.
+2. **Spawn a Foreman subagent to run the omp loop.** The Foreman invokes
+   `scripts/omp-build "<spec>"`, answers omp's questions, iterates in a bounded
+   Q&A loop, and does the first-pass review. `omp` runs autonomously but is
+   contained to the local working tree (auto-approved, unlimited subagents, but
+   **no** github/ssh/browser/web and **no** push/PR/merge). The Foreman does not
+   cross the boundary either.
+3. **You cross the boundary, never the Foreman or `omp`.** You push the branch
+   and open the PR; `omp` only commits locally.
 4. **Review independently** — the omp-authored diff against the user's original
    intent and the acceptance criteria.
 5. **Merge = auto-ship guardrails + your validation.** The auto-ship

--- a/OMP.md
+++ b/OMP.md
@@ -1,0 +1,104 @@
+# OMP.md — the Claude × omp build pipeline
+
+This repo uses a two-agent model for substantial implementation work:
+
+> **Claude Code plans and guards. `omp` (the oh-my-pi coding agent) implements.
+> The box — the local working tree — is the boundary. Claude owns everything
+> that leaves it.**
+
+`omp` is a full, autonomous coding agent (its own `bash`/`edit`/`write`/`ssh`/
+`browser`/`github`/`task` tools, persistent memory, subagents, multi-provider).
+Invoking it is closer to handing the keys to a second coding agent than to
+running a command — so it runs under the contract below, never ad hoc.
+
+## The flow
+
+```
+you (human): a request
+ └─ Claude: turn it into a SPEC with explicit, testable acceptance criteria
+            (the exact tests/commands that must pass)
+     └─ omp: implement it  ── bounded Q&A loop with Claude ──┐
+        · scoped to the repo, auto-approved, UNLIMITED subagents
+        · local tools only — no github / ssh / browser / web
+        · cannot push, open PRs, or merge
+     └─ Claude: push the branch + open the PR  ◄────────────-┘
+         └─ Claude: review the diff independently, against the user's
+                    ORIGINAL intent and the acceptance criteria
+             └─ merge = auto-ship guardrails + Claude's validation (see below)
+```
+
+Use the pipeline for substantial, multi-file work. Small changes Claude just
+makes directly.
+
+## The box boundary (the one rule that matters)
+
+- **Inside the box** (the local working tree): `omp` has full autonomy —
+  read/edit/write, run builds/tests, commit locally, and spawn as many
+  subagents as it wants. Blast radius is files Claude reviews before anything
+  leaves.
+- **Crossing the box** (push / open PR / merge / deploy / any external service):
+  **only Claude**, under its normal confirmation rules. `omp` is never granted
+  the tools or credentials to cross it.
+
+This is enforced structurally, not by trust:
+
+1. `omp` is launched (via `scripts/omp-build`) with a local-only `--tools`
+   whitelist — no `github`, `ssh`, `browser`, or `web_search`.
+2. This environment has no `gh` CLI and `omp` is given no push credentials, so
+   it *cannot* reach GitHub even if it tried.
+3. `omp` runs with `--no-rules --no-extensions`, so it does not ingest this
+   repo's `CLAUDE.md` (including the auto-ship authorization) and cannot act on
+   it. Its instructions come only from the spec Claude hands it.
+
+## Invocation
+
+Always through the wrapper, never raw:
+
+```sh
+scripts/omp-build "<spec with acceptance criteria>"
+scripts/omp-build @spec.md
+```
+
+`scripts/omp-build` bakes in: `--cwd <repo>`, the local-only tool set,
+`--approval-mode yolo` (safe — the boundary is structural), `--no-rules
+--no-extensions`, the curated `sa-*` skills, and **unlimited subagents**
+(`task.maxConcurrency = 0`). Pin a specific Claude model with the
+`OMP_BUILD_MODEL` env var; with only the Anthropic key provisioned, omp
+defaults to Claude.
+
+## Preloaded skills (curated, not kitchen-sink)
+
+`omp` loads a small, deliberate set from `.omp/skills/` (scoped to `sa-*`):
+
+- **`sa-stay-in-box`** — the boundary, restated at the instruction level.
+- **`sa-self-verify`** — run the repo's tests/linters and re-check the diff
+  against the acceptance criteria before yielding; report, don't guess.
+- a project-conventions skill (`sa-python-service` or `sa-jekyll-docs`).
+
+Grow this set from observed mistakes; keep it lean so omp stays focused.
+
+## Subagents
+
+Completely open by design: `task.maxConcurrency = 0` (no cap on concurrent
+subagents). Only the *recursion depth* is kept finite (`maxRecursionDepth = 5`),
+purely to prevent an infinite agent-spawn loop — not to limit how many
+subagents run at once.
+
+## Merge gate
+
+The standing **auto-ship** authorization in `CLAUDE.md` still applies, but for
+any `omp`-authored change Claude's independent review is an **additional hard
+gate**. Squash-merge only when:
+
+- CI is green (or none is configured), **and**
+- there are no unresolved human review comments, **and**
+- Claude's independent review of the diff is clean.
+
+If Claude's review flags anything material, it does **not** merge — it reports
+and waits.
+
+## Accountability
+
+Claude owns the merged result, not `omp`. Claude reviews every omp-authored diff
+before it ships and tells the human what changed and which tools/model `omp`
+used. Never echo, log, or commit the `OMP_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`.

--- a/OMP.md
+++ b/OMP.md
@@ -1,46 +1,80 @@
 # OMP.md — the Claude × omp build pipeline
 
-This repo uses a two-agent model for substantial implementation work:
+This repo uses a **three-tier** model for substantial implementation work:
 
-> **Claude Code plans and guards. `omp` (the oh-my-pi coding agent) implements.
-> The box — the local working tree — is the boundary. Claude owns everything
-> that leaves it.**
+> **Director (human + Claude) sets intent and guards. A foreman (a Claude
+> subagent) manages the worker. The worker (`omp`) implements inside the box.
+> The box — the local working tree — is the boundary, and only the Director
+> crosses it.**
 
 `omp` is a full, autonomous coding agent (its own `bash`/`edit`/`write`/`ssh`/
-`browser`/`github`/`task` tools, persistent memory, subagents, multi-provider).
-Invoking it is closer to handing the keys to a second coding agent than to
-running a command — so it runs under the contract below, never ad hoc.
+`browser`/`github`/`task` tools, persistent memory, subagents, multi-provider) —
+but on *this* project it is a **capable greenhorn**: fast hands, no shared
+history, and it will make rookie mistakes until it is coached. Treat it
+accordingly. Invoking it is closer to onboarding a new contractor than running a
+command, so it always runs under the contract below, never ad hoc.
+
+## Operating tiers
+
+| Tier | Who | Owns |
+| --- | --- | --- |
+| **Director** | the human + the top-level Claude session | intent, scope, the spec, crossing the box boundary (push / PR / merge), merge-safety. Operates at the director level — does not babysit omp directly. |
+| **Foreman** | a Claude **subagent** the Director spawns per build task | driving the omp loop: hand omp the spec, run `scripts/omp-build`, answer omp's questions, iterate, do the first-pass review, and report results up. Keeps omp-wrangling out of the Director's context. **Does not cross the box** either. |
+| **Worker** | `omp` | implementing inside the working tree. |
+
+Both Foreman and Worker live **inside the box**. Only the Director pushes, opens
+PRs, or merges.
 
 ## The flow
 
 ```
-you (human): a request
- └─ Claude: turn it into a SPEC with explicit, testable acceptance criteria
-            (the exact tests/commands that must pass)
-     └─ omp: implement it  ── bounded Q&A loop with Claude ──┐
-        · scoped to the repo, auto-approved, UNLIMITED subagents
-        · local tools only — no github / ssh / browser / web
-        · cannot push, open PRs, or merge
-     └─ Claude: push the branch + open the PR  ◄────────────-┘
-         └─ Claude: review the diff independently, against the user's
-                    ORIGINAL intent and the acceptance criteria
-             └─ merge = auto-ship guardrails + Claude's validation (see below)
+Director (human): a request
+ └─ Director (Claude): turn it into a SPEC with explicit, testable
+                       acceptance criteria (exact tests/commands that must pass)
+     └─ spawn a FOREMAN subagent, hand it the spec
+         └─ Foreman ⇄ omp: implement it  (bounded Q&A loop)
+            · omp scoped to the repo, auto-approved, UNLIMITED subagents
+            · local tools only — no github / ssh / browser / web
+            · omp cannot push, open PRs, or merge
+         └─ Foreman: first-pass review of omp's diff; report up to Director
+     └─ Director (Claude): push the branch + open the PR
+         └─ Director: independent review vs. the user's ORIGINAL intent
+                      and the acceptance criteria
+             └─ merge = auto-ship guardrails + Director's validation (below)
 ```
 
-Use the pipeline for substantial, multi-file work. Small changes Claude just
-makes directly.
+Use the pipeline for substantial, multi-file work. Small changes the Director
+just makes directly.
+
+## Onboarding the greenhorn
+
+`omp` has no memory of this project between runs. Set it up to succeed:
+
+- **Write generous specs.** A greenhorn needs more than a one-liner: state the
+  goal, the exact files/areas in scope, what is explicitly out of scope, the
+  acceptance criteria (tests/commands), and any gotchas. Vague specs get vague
+  work.
+- **Point it at its bearings.** The `sa-orientation` skill tells omp to read
+  the README, the entry-point module, and the relevant tests, and to run the
+  suite once for a green baseline before changing anything.
+- **Review closely, early.** Expect rookie mistakes on the first tasks. The
+  Foreman checks omp's diff carefully and sends it back to fix its own misses
+  rather than papering over them.
+- **Coach by accretion.** When omp repeats a mistake, capture the correction as
+  a new `sa-*` skill (or tighten an existing one). The skill set is how the
+  greenhorn becomes a journeyman — keep it lean and specific.
 
 ## The box boundary (the one rule that matters)
 
-- **Inside the box** (the local working tree): `omp` has full autonomy —
-  read/edit/write, run builds/tests, commit locally, and spawn as many
-  subagents as it wants. Blast radius is files Claude reviews before anything
-  leaves.
+- **Inside the box** (the local working tree): Foreman + `omp` have full
+  autonomy — read/edit/write, run builds/tests, commit locally, and omp may
+  spawn as many subagents as it wants. Blast radius is files the Director
+  reviews before anything leaves.
 - **Crossing the box** (push / open PR / merge / deploy / any external service):
-  **only Claude**, under its normal confirmation rules. `omp` is never granted
-  the tools or credentials to cross it.
+  **only the Director**, under normal confirmation rules. Neither the Foreman
+  nor `omp` is granted the tools or credentials to cross it.
 
-This is enforced structurally, not by trust:
+Enforced structurally, not by trust:
 
 1. `omp` is launched (via `scripts/omp-build`) with a local-only `--tools`
    whitelist — no `github`, `ssh`, `browser`, or `web_search`.
@@ -48,11 +82,11 @@ This is enforced structurally, not by trust:
    it *cannot* reach GitHub even if it tried.
 3. `omp` runs with `--no-rules --no-extensions`, so it does not ingest this
    repo's `CLAUDE.md` (including the auto-ship authorization) and cannot act on
-   it. Its instructions come only from the spec Claude hands it.
+   it. Its instructions come only from the spec the Foreman hands it.
 
 ## Invocation
 
-Always through the wrapper, never raw:
+The Foreman invokes `omp` only through the wrapper, never raw:
 
 ```sh
 scripts/omp-build "<spec with acceptance criteria>"
@@ -63,13 +97,15 @@ scripts/omp-build @spec.md
 `--approval-mode yolo` (safe — the boundary is structural), `--no-rules
 --no-extensions`, the curated `sa-*` skills, and **unlimited subagents**
 (`task.maxConcurrency = 0`). Pin a specific Claude model with the
-`OMP_BUILD_MODEL` env var; with only the Anthropic key provisioned, omp
-defaults to Claude.
+`OMP_BUILD_MODEL` env var; with only the Anthropic key provisioned, omp defaults
+to Claude.
 
 ## Preloaded skills (curated, not kitchen-sink)
 
 `omp` loads a small, deliberate set from `.omp/skills/` (scoped to `sa-*`):
 
+- **`sa-orientation`** — how to get your bearings on this repo before changing
+  anything (a greenhorn's first move).
 - **`sa-stay-in-box`** — the boundary, restated at the instruction level.
 - **`sa-self-verify`** — run the repo's tests/linters and re-check the diff
   against the acceptance criteria before yielding; report, don't guess.
@@ -81,24 +117,24 @@ Grow this set from observed mistakes; keep it lean so omp stays focused.
 
 Completely open by design: `task.maxConcurrency = 0` (no cap on concurrent
 subagents). Only the *recursion depth* is kept finite (`maxRecursionDepth = 5`),
-purely to prevent an infinite agent-spawn loop — not to limit how many
-subagents run at once.
+purely to prevent an infinite agent-spawn loop — not to limit how many run at
+once.
 
 ## Merge gate
 
 The standing **auto-ship** authorization in `CLAUDE.md` still applies, but for
-any `omp`-authored change Claude's independent review is an **additional hard
-gate**. Squash-merge only when:
+any `omp`-authored change the Director's independent review is an **additional
+hard gate**. Squash-merge only when:
 
 - CI is green (or none is configured), **and**
 - there are no unresolved human review comments, **and**
-- Claude's independent review of the diff is clean.
+- the Director's independent review of the diff is clean.
 
-If Claude's review flags anything material, it does **not** merge — it reports
-and waits.
+If the review flags anything material, do **not** merge — report and wait.
 
 ## Accountability
 
-Claude owns the merged result, not `omp`. Claude reviews every omp-authored diff
-before it ships and tells the human what changed and which tools/model `omp`
-used. Never echo, log, or commit the `OMP_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`.
+The Director owns the merged result, not the Foreman and not `omp`. Every
+omp-authored diff is reviewed before it ships, and the human is told what
+changed and which tools/model `omp` used. Never echo, log, or commit the
+`OMP_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`.

--- a/_config.yml
+++ b/_config.yml
@@ -74,3 +74,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - .gitignore
+  - CLAUDE.md
+  - OMP.md
+  - scripts/
+  - .omp/

--- a/scripts/omp-build
+++ b/scripts/omp-build
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# omp-build — delegate a scoped implementation task to the omp coding agent,
+# contained to the local working tree.
+#
+# Part of the "Claude orchestrates, omp implements" pipeline. See OMP.md for the
+# full operating model and rationale.
+#
+# Usage:
+#   scripts/omp-build "<spec text>"
+#   scripts/omp-build @spec.md
+#   echo "<spec>" | scripts/omp-build
+#
+# omp runs autonomously INSIDE the working tree (auto-approved, unlimited
+# subagents) but is given NO boundary-crossing tools: no github, ssh, browser,
+# or web access. The orchestrating Claude session owns everything that leaves
+# the box (push, pull request, merge).
+
+set -euo pipefail
+
+if ! command -v omp >/dev/null 2>&1; then
+  echo "omp-build: 'omp' is not installed in this environment" >&2
+  exit 127
+fi
+
+# Repo root, so omp is scoped correctly no matter where this is invoked from.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Only the Anthropic key is provisioned, so omp defaults to Claude. Override
+# with OMP_BUILD_MODEL to pin a specific Claude model.
+MODEL="${OMP_BUILD_MODEL:-}"
+
+# Subagents: completely open. 0 = unlimited concurrent subagents.
+# Config lives in an ephemeral dir, so (re)apply it every run.
+omp config set task.maxConcurrency 0    >/dev/null   # no cap on concurrent subagents
+omp config set task.maxRecursionDepth 5 >/dev/null   # nesting depth; finite only to avoid an infinite spawn loop
+omp config set task.batch true          >/dev/null
+
+# Local-only tool surface: full implementation power + subagents, but nothing
+# that can cross the box boundary. (omp's regex tool is `search`, not `grep`.)
+TOOLS="read,edit,write,search,find,bash,lsp,task,todo"
+
+# Gather the spec from args, an @file, or stdin.
+if [ "$#" -gt 0 ]; then
+  SPEC=("$@")
+elif [ ! -t 0 ]; then
+  SPEC=("$(cat)")
+else
+  echo "omp-build: provide a spec as an argument, @file, or on stdin" >&2
+  exit 2
+fi
+
+echo "omp-build: delegating to omp (cwd=$REPO_ROOT, tools=$TOOLS, subagents=unlimited)" >&2
+
+exec omp -p \
+  ${MODEL:+--model "$MODEL"} \
+  --cwd "$REPO_ROOT" \
+  --no-rules --no-extensions \
+  --skills 'sa-*' \
+  --tools "$TOOLS" \
+  --approval-mode yolo \
+  "${SPEC[@]}"


### PR DESCRIPTION
## What

Introduces a two-agent build workflow where **Claude Code plans and guards** while **`omp` (the oh-my-pi coding agent) implements**, contained to the local working tree.

The governing principle: **the box (the working tree) is the boundary.** `omp` gets full autonomy *inside* it (auto-approved edits, unlimited subagents) but is structurally unable to cross it — Claude owns push, PR, and merge.

## Files

- **`OMP.md`** — operating model, the structural box boundary, and the merge gate.
- **`scripts/omp-build`** — the only sanctioned way to invoke `omp`. Bakes in a local-only `--tools` whitelist (no `github`/`ssh`/`browser`/`web_search`), `--no-rules --no-extensions` (so omp never ingests `CLAUDE.md`'s auto-ship authorization), curated `sa-*` skills, `--approval-mode yolo`, and **unlimited subagents** (`task.maxConcurrency = 0`).
- **`.omp/skills/sa-{stay-in-box,self-verify,jekyll-docs}`** — a curated (not kitchen-sink) preloaded skill set: the boundary restated, a self-verify-before-yielding discipline, and Jekyll/docs conventions.
- **`CLAUDE.md`** — pipeline section + a validation gate layered on the existing auto-ship authorization.
- **`_config.yml`** — excludes `OMP.md`, `scripts/`, and `.omp/` from the published GitHub Pages site so they never render as pages.

## How the boundary is enforced (structurally, not by trust)

1. Local-only tool whitelist in the wrapper.
2. No `gh` CLI and no push credentials available to `omp` in the execution environment.
3. `--no-rules --no-extensions` so omp's instructions come only from the spec Claude hands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tsk9mvt9RmsZXQJXDyEdAc)_