### PR TITLE
workflow: bake in omp pipeline lessons (don't interrupt omp; verify-and-merge)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,12 +42,17 @@ The short version:
    greenhorn to follow.
 2. **Spawn a Foreman subagent to run the omp loop.** The Foreman invokes
    `scripts/omp-build "<spec>"`, answers omp's questions, iterates in a bounded
-   Q&A loop, and does the first-pass review. `omp` runs autonomously but is
-   contained to the local working tree (auto-approved, unlimited subagents, but
-   **no** github/ssh/browser/web and **no** push/PR/merge). The Foreman does not
-   cross the boundary either.
+   Q&A loop, and does the first-pass review. It drives omp **synchronously to
+   completion** (runs in the foreground and blocks until omp returns) — it never
+   backgrounds omp and rests. `omp` runs autonomously but is contained to the
+   local working tree (auto-approved, unlimited subagents, but **no**
+   github/ssh/browser/web and **no** push/PR/merge). The Foreman does not cross
+   the boundary either. **Never interrupt omp** — don't kill it or touch the
+   working tree / git while it runs; it commits its own work when done.
 3. **You cross the boundary, never the Foreman or `omp`.** You push the branch
-   and open the PR; `omp` only commits locally.
+   and open the PR; `omp` only commits locally — that local commit is the
+   expected successful outcome (check `git log` for it before concluding omp
+   "did nothing"). Your job is to verify it and merge, not to redo it.
 4. **Review independently** — the omp-authored diff against the user's original
    intent and the acceptance criteria.
 5. **Merge = auto-ship guardrails + your validation.** The auto-ship

--- a/OMP.md
+++ b/OMP.md
@@ -19,7 +19,7 @@ command, so it always runs under the contract below, never ad hoc.
 | Tier | Who | Owns |
 | --- | --- | --- |
 | **Director** | the human + the top-level Claude session | intent, scope, the spec, crossing the box boundary (push / PR / merge), merge-safety. Operates at the director level — does not babysit omp directly. |
-| **Foreman** | a Claude **subagent** the Director spawns per build task | driving the omp loop: hand omp the spec, run `scripts/omp-build`, answer omp's questions, iterate, do the first-pass review, and report results up. Keeps omp-wrangling out of the Director's context. **Does not cross the box** either. |
+| **Foreman** | a Claude **subagent** the Director spawns per build task | driving the omp loop **synchronously to completion**: hand omp the spec, run `scripts/omp-build` in the foreground and block until it returns, answer omp's questions, iterate, do the first-pass review, and report results up. Never backgrounds omp and rests. Keeps omp-wrangling out of the Director's context. **Does not cross the box** either. |
 | **Worker** | `omp` | implementing inside the working tree. |
 
 Both Foreman and Worker live **inside the box**. Only the Director pushes, opens
@@ -45,6 +45,35 @@ Director (human): a request
 
 Use the pipeline for substantial, multi-file work. Small changes the Director
 just makes directly.
+
+## Driving the loop — rules learned the hard way
+
+These are non-negotiable. Each one cost a botched run before it was written down.
+
+1. **Never interrupt omp. Let it finish.** Do not `kill`/`pkill`/signal the omp
+   process, and do **not** touch the working tree or run state-changing git
+   (`commit`/`add`/`reset`/`rebase`/`amend`) while omp is running — you share its
+   `.git`, and rewriting history or editing files under it can corrupt a build
+   that was about to succeed. A tree that looks half-written or uncommitted
+   mid-run is **normal progress, not failure**; snapshots taken while omp writes
+   will race. Wait for omp to return.
+2. **omp commits its own work locally — that is success, not a problem.** The
+   expected end state of a run is omp's own local commit. The Director does
+   **not** re-do, re-stage, or re-commit omp's work. If you think omp "produced
+   nothing," check `git log` for its commit before concluding anything — it has
+   probably already committed.
+3. **The Foreman runs omp synchronously and reports once.** Invoke
+   `scripts/omp-build` in the foreground and block until it exits; never launch
+   omp in the background (e.g. via a Monitor / `run_in_background`) and end the
+   turn. Spawn the Foreman subagent **synchronously** so it returns one complete
+   report. A Foreman that backgrounds omp and goes to rest has not done its job.
+4. **After omp returns, the Director's whole job is verify-and-merge.** Review
+   the committed diff against the original intent and the acceptance criteria,
+   run the tests, then push → PR → merge. That's it — don't babysit omp and don't
+   rebuild what it already built.
+5. **Watch GitHub; don't poll or interrupt.** Drive on PR events via the
+   subscription (CI failures, review comments). Don't busy-poll or sit
+   interrupting things while waiting.
 
 ## Onboarding the greenhorn
 
@@ -98,7 +127,9 @@ scripts/omp-build @spec.md
 --no-extensions`, the curated `sa-*` skills, and **unlimited subagents**
 (`task.maxConcurrency = 0`). Pin a specific Claude model with the
 `OMP_BUILD_MODEL` env var; with only the Anthropic key provisioned, omp defaults
-to Claude.
+to Claude. The wrapper also maps `OMP_ANTHROPIC_API_KEY` → `ANTHROPIC_API_KEY`
+automatically, so omp authenticates without the Foreman exporting it by hand (a
+missing key used to make omp launch and silently hang).
 
 ## Preloaded skills (curated, not kitchen-sink)
 

--- a/scripts/omp-build
+++ b/scripts/omp-build
@@ -22,6 +22,14 @@ if ! command -v omp >/dev/null 2>&1; then
   exit 127
 fi
 
+# omp authenticates with ANTHROPIC_API_KEY, but this environment provisions the
+# key as OMP_ANTHROPIC_API_KEY. Map it through so omp (and the `omp config` calls
+# below) authenticate without the caller having to export it by hand. This was a
+# recurring foot-gun: a missing key makes omp launch and silently hang.
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -n "${OMP_ANTHROPIC_API_KEY:-}" ]; then
+  export ANTHROPIC_API_KEY="$OMP_ANTHROPIC_API_KEY"
+fi
+
 # Repo root, so omp is scoped correctly no matter where this is invoked from.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 


### PR DESCRIPTION
Bakes in lessons from a bumpy omp run so they can't recur. Identical change across all three repos (the pipeline files are shared boilerplate).

**Code fix** — `scripts/omp-build` now maps `OMP_ANTHROPIC_API_KEY` → `ANTHROPIC_API_KEY` automatically (before the `omp config` calls). A missing key used to make omp launch and silently hang; the Foreman had to export it by hand every time.

**Governance** — `OMP.md` (new "Driving the loop — rules learned the hard way" section) + `CLAUDE.md`:
- **Never interrupt omp** — no kill/signal, and don't touch the working tree or run git while it's running (shared `.git`).
- **omp commits its own work locally — that commit is the expected successful outcome.** Check `git log` before concluding omp "did nothing"; don't redo/re-commit its work.
- **The Foreman drives omp synchronously to completion** (foreground, blocks until omp returns) — never backgrounds omp and rests.
- **The Director's job after omp returns is verify-and-merge**, nothing more.
- **Watch GitHub via PR events**, don't poll/interrupt.

No code paths affected beyond the wrapper's env mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw9NHYdr5vRTfTtQopqNkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw9NHYdr5vRTfTtQopqNkQ)_