### PR TITLE
Roadmap: keep feature-vote links white across all states (fix visited-link blue)

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -394,7 +394,12 @@ details.safeguards li { margin-bottom: 0.2rem; }
    ════════════════════════════════════════════════════════════════════════ */
 .roadmap-hero { background: rgba(46, 204, 113, 0.10); border-left-color: #2ecc71; color: #e6e9f0; }
 .lp-q { color: #e6e9f0; }
-.lp-label a { color: #cdd4e3; }
+.lp-label a,
+.lp-label a:link,
+.lp-label a:visited,
+.lp-label a:hover,
+.lp-label a:focus,
+.lp-label a:active { color: #fff; }
 .lp-track { background: rgba(255, 255, 255, 0.12); height: 16px; }
 .lp-fill { background: linear-gradient(90deg, #6c3483, #a569bd); }
 .lp-fill.gold { background: linear-gradient(90deg, #b7950b, #f1c40f); }


### PR DESCRIPTION
## What

On the public Roadmap page, the "Live community vote" feature links rendered blue once clicked (and inconsistent between visited/unvisited).

## Why

`.lp-label a` set only a base `color: #cdd4e3` with no `:visited`/`:hover`/`:focus`/`:active` — so those states fell back to the Minima theme's default link palette (unvisited blue, a different visited color). Hence "some blue, some not": already-clicked links diverged from unvisited ones.

## Fix

Pin every link state to white:

```css
.lp-label a, .lp-label a:link, .lp-label a:visited,
.lp-label a:hover, .lp-label a:focus, .lp-label a:active { color: #fff; }
```

Scoped to `.lp-label a` (exclusive to the vote list), in the dark-theme block so source order wins — no `!important`. No other link colors touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM)_