### PR TITLE
Roadmap: live countdown to vote close instead of a fixed date

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1083,6 +1083,11 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
   if (!box) return;
   var API = "https://sa.wandweb.co/api/public/poll-results";
 
+  // Close timestamp of the current active poll (ISO string), or null when no
+  // poll is open / it has closed. Drives the live "closes in 1d 22h" countdown,
+  // kept current by the per-second ticker below between 60s data refreshes.
+  var pollClosesAt = null;
+
   function esc(s) {
     return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
   }
@@ -1183,17 +1188,46 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
         });
       }
     });
-    var closes = "";
-    if (p.status === "active" && p.closes_at) {
-      var d = new Date(p.closes_at);
-      if (!isNaN(d)) closes = " · closes " + d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-    }
+    // Remember this poll's close time so the 1s ticker can keep the countdown
+    // live between the (60s) data refreshes.
+    pollClosesAt = (p.status === "active" && p.closes_at) ? p.closes_at : null;
     var meta = box.querySelector("#lp-meta");
-    if (meta) meta.textContent =
-      total + " votes · " + (p.servers || 0) + " server" + (p.servers === 1 ? "" : "s") + closes +
-      (p.status === "active"
-        ? " · 🟢 live — vote from your server's staff chat; every staff member has a voice"
-        : " · ✅ closed — thank you!");
+    if (meta) {
+      // The vote/server counts come from the data refresh; the close countdown
+      // is its own span so the per-second ticker can update only that part.
+      meta.innerHTML =
+        esc(total + " votes · " + (p.servers || 0) + " server" + (p.servers === 1 ? "" : "s")) +
+        '<span id="lp-closes"></span>' +
+        (p.status === "active"
+          ? " · 🟢 live — vote from your server's staff chat; every staff member has a voice"
+          : " · ✅ closed — thank you!");
+      tickCloseCountdown();
+    }
+  }
+
+  // Live countdown to the poll close, e.g. " · closes in 1d 22h", recomputed on
+  // each tick from the close timestamp. Shows " · voting closed" once the close
+  // time has passed; renders nothing when there's no active close time.
+  function formatCountdown(closesAt) {
+    if (!closesAt) return "";
+    var d = new Date(closesAt);
+    if (isNaN(d)) return "";
+    var ms = d.getTime() - Date.now();
+    if (ms <= 0) return " · voting closed";
+    var totalMin = Math.floor(ms / 60000);
+    var days = Math.floor(totalMin / 1440);
+    var hours = Math.floor((totalMin % 1440) / 60);
+    var mins = totalMin % 60;
+    var parts;
+    if (days > 0) parts = days + "d " + hours + "h";
+    else if (hours > 0) parts = hours + "h " + mins + "m";
+    else parts = mins + "m";
+    return " · closes in " + parts;
+  }
+
+  function tickCloseCountdown() {
+    var el = document.getElementById("lp-closes");
+    if (el) el.textContent = formatCountdown(pollClosesAt);
   }
 
   function renderBands(t, total, nAnswers) {
@@ -1286,8 +1320,10 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
     setTimeout(function () { refresh(); schedule(); }, nextRefreshAt - Date.now());
   }
 
-  // Visible countdown to the next data refresh, ticking every second
+  // Visible countdown to the next data refresh + the live poll-close countdown,
+  // both ticking every second.
   setInterval(function () {
+    tickCloseCountdown();
     var el = document.getElementById("lp-refresh");
     if (!el) return;
     var s = Math.max(0, Math.ceil((nextRefreshAt - Date.now()) / 1000));

--- a/roadmap.md
+++ b/roadmap.md
@@ -394,7 +394,12 @@ details.safeguards li { margin-bottom: 0.2rem; }
    ════════════════════════════════════════════════════════════════════════ */
 .roadmap-hero { background: rgba(46, 204, 113, 0.10); border-left-color: #2ecc71; color: #e6e9f0; }
 .lp-q { color: #e6e9f0; }
-.lp-label a { color: #cdd4e3; }
+.lp-label a,
+.lp-label a:link,
+.lp-label a:visited,
+.lp-label a:hover,
+.lp-label a:focus,
+.lp-label a:active { color: #fff; }
 .lp-track { background: rgba(255, 255, 255, 0.12); height: 16px; }
 .lp-fill { background: linear-gradient(90deg, #6c3483, #a569bd); }
 .lp-fill.gold { background: linear-gradient(90deg, #b7950b, #f1c40f); }


### PR DESCRIPTION
## What

On the public Roadmap's "Live community vote" meta line, replaces the static "closes Jun 20" with a **live countdown** ("closes in 1d 22h") computed from the poll's close timestamp.

- `formatCountdown(closesAt)` → " · closes in 1d 22h" (narrows to `Xh Ym` / `Xm` as it shrinks); " · voting closed" once past; "" when there's no active close time.
- Renders into a dedicated `#lp-closes` span and ticks via the page's **existing** 1s `setInterval` (no new timer); vote/server counts still come from the 60s data fetch. Inherits `.lp-meta` styling — dark theme unchanged.

Automatically retroactive for the current vote (it just renders from the close date). Validated with `node --check` + a functional harness (1d22h / 3h5m / 45m / closed / null / bad-input).

Deploys via GitHub Pages on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM)_