### PR TITLE
Changelog: backfill v5.6.32–5.6.35; omp pipeline memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,36 +25,50 @@ change — never force-push.
 
 _To revoke this, delete this section._
 
-## Multi-agent build pipeline — Claude orchestrates, omp implements
+## Build pipeline — Director orchestrates, omp implements (omp is default-on for builds)
 
-For substantial implementation work this repo uses a **three-tier** model: the
-**Director** (the human + you) sets intent and guards; a **Foreman** (a Claude
-subagent you spawn) manages the worker; the **Worker** (`omp`, the oh-my-pi
-coding agent) implements. You and the human operate at the director level — you
-do not babysit `omp` directly. Treat `omp` as a **capable greenhorn**: fast, but
-new to this project and in need of onboarding. Full operating model and
-rationale: [`OMP.md`](OMP.md).
+For substantial implementation work this repo uses **omp** (the oh-my-pi coding
+agent) as the implementer **by default**. You — with the human — are the
+**Director**: you set intent, guard the boundary, review, and ship. Treat `omp`
+as a **capable greenhorn**: fast and cheap, contained to the local working tree,
+and it **learns the house rules from the committed `.omp/skills/sa-*` set it
+loads on every run**. Full operating model and rationale: [`OMP.md`](OMP.md).
 
-The short version:
+Two standing principles — the Director session is the expensive one, so protect it:
 
-1. **Turn the user's request into a spec** with explicit, testable acceptance
+- **Read once, don't re-derive.** The durable lessons live in this `CLAUDE.md`
+  and the `.omp/skills/sa-*` skills (omp loads them; you read them). Don't burn
+  Director tokens re-learning what's already written — and when you learn
+  something durable, write it back into a skill so it never has to be learned
+  again.
+- **Keep the Director free.** Default to driving omp **backgrounded** so you stay
+  interactive with the human on the fly, and delegate research to subagents
+  rather than reading large files into the Director context.
+
+The loop:
+
+1. **Spec it.** Turn the request into a spec with explicit, testable acceptance
    criteria (the exact tests/commands that must pass) — generous enough for a
    greenhorn to follow.
-2. **Spawn a Foreman subagent to run the omp loop.** The Foreman invokes
-   `scripts/omp-build "<spec>"`, answers omp's questions, iterates in a bounded
-   Q&A loop, and does the first-pass review. It drives omp **synchronously to
-   completion** (runs in the foreground and blocks until omp returns) — it never
-   backgrounds omp and rests. `omp` runs autonomously but is contained to the
-   local working tree (auto-approved, unlimited subagents, but **no**
-   github/ssh/browser/web and **no** push/PR/merge). The Foreman does not cross
-   the boundary either. **Never interrupt omp** — don't kill it or touch the
-   working tree / git while it runs; it commits its own work when done.
-3. **You cross the boundary, never the Foreman or `omp`.** You push the branch
-   and open the PR; `omp` only commits locally — that local commit is the
-   expected successful outcome (check `git log` for it before concluding omp
-   "did nothing"). Your job is to verify it and merge, not to redo it.
-4. **Review independently** — the omp-authored diff against the user's original
-   intent and the acceptance criteria.
+2. **Drive omp — backgrounded by default.** You (the top-level session) run
+   `scripts/omp-build` in the **background** with output to a log, then return at
+   once and stay reachable. The run wakes you on exit; **verify omp's commit
+   landed** (`git log`) before anything else — an unchanged HEAD with a clean tree
+   means omp produced nothing, so re-drive it. `omp` runs autonomously, contained
+   to the working tree (auto-approved, unlimited subagents) with **no**
+   boundary-crossing tools (no github/ssh/web, no push/PR/merge); `omp-build`
+   runs it under a scrubbed HOME so containment can't be defeated through its
+   `bash` tool. *Optional:* spawn a Foreman subagent to keep omp's chatter out of
+   your context — but a subagent gets **one turn** and its child is reaped when it
+   ends, so it must drive omp to completion within that turn and must **never**
+   `run_in_background` then rest. **Never interrupt omp** — don't kill it or touch
+   the working tree / git while it runs; it commits its own work when done.
+3. **You cross the boundary, never `omp`.** You push the branch and open the PR;
+   `omp` only commits locally — that local commit is the expected successful
+   outcome (check `git log` before concluding omp "did nothing"). Verify and
+   merge, don't redo.
+4. **Review independently** — the omp-authored diff against the original intent
+   and the acceptance criteria.
 5. **Merge = auto-ship guardrails + your validation.** The auto-ship
    authorization above still applies, but for any `omp`-authored change your
    independent review is an additional hard gate: squash-merge only when CI is

--- a/OMP.md
+++ b/OMP.md
@@ -18,8 +18,8 @@ command, so it always runs under the contract below, never ad hoc.
 
 | Tier | Who | Owns |
 | --- | --- | --- |
-| **Director** | the human + the top-level Claude session | intent, scope, the spec, crossing the box boundary (push / PR / merge), merge-safety. Operates at the director level — does not babysit omp directly. |
-| **Foreman** | a Claude **subagent** the Director spawns per build task | driving the omp loop **synchronously to completion**: hand omp the spec, run `scripts/omp-build` in the foreground and block until it returns, answer omp's questions, iterate, do the first-pass review, and report results up. Never backgrounds omp and rests. Keeps omp-wrangling out of the Director's context. **Does not cross the box** either. |
+| **Director** | the human + the top-level Claude session | intent, scope, the spec, crossing the box boundary (push / PR / merge), merge-safety. Drives omp by **backgrounding** `scripts/omp-build` (output → a log) and **stays reachable to the human** while it runs, verifying omp's commit when the run wakes it on exit. Operates at the director level — does not babysit omp directly. |
+| **Foreman** *(optional)* | a Claude **subagent** the Director may spawn when it wants omp-wrangling kept out of its own context | driving the omp loop **to completion within its single turn**: hand omp the spec, run `scripts/omp-build`, answer omp's questions, iterate, do the first-pass review, report up. A subagent gets exactly one turn and its children are reaped when it ends, so it must block to completion (or background **and** actively wait) — it must **never** `run_in_background` then rest. **Does not cross the box** either. By default the Director drives omp itself, backgrounded (rule 3). |
 | **Worker** | `omp` | implementing inside the working tree. |
 
 Both Foreman and Worker live **inside the box**. Only the Director pushes, opens
@@ -31,12 +31,15 @@ PRs, or merges.
 Director (human): a request
  └─ Director (Claude): turn it into a SPEC with explicit, testable
                        acceptance criteria (exact tests/commands that must pass)
-     └─ spawn a FOREMAN subagent, hand it the spec
-         └─ Foreman ⇄ omp: implement it  (bounded Q&A loop)
+     └─ Director: launch `scripts/omp-build` in the BACKGROUND (output → log),
+                  then return and STAY REACHABLE; the run wakes the Director
+                  on exit  (or, to isolate context, spawn a Foreman that drives
+                  omp to completion within ONE turn — never background-and-rest)
+         └─ omp: implement it inside the box  (bounded Q&A loop)
             · omp scoped to the repo, auto-approved, UNLIMITED subagents
             · local tools only — no github / ssh / browser / web
             · omp cannot push, open PRs, or merge
-         └─ Foreman: first-pass review of omp's diff; report up to Director
+         └─ on exit: VERIFY omp's commit exists (git log) before anything else
      └─ Director (Claude): push the branch + open the PR
          └─ Director: independent review vs. the user's ORIGINAL intent
                       and the acceptance criteria
@@ -62,16 +65,32 @@ These are non-negotiable. Each one cost a botched run before it was written down
    **not** re-do, re-stage, or re-commit omp's work. If you think omp "produced
    nothing," check `git log` for its commit before concluding anything — it has
    probably already committed.
-3. **The Foreman runs omp synchronously and reports once.** Invoke
-   `scripts/omp-build` in the foreground and block until it exits; never launch
-   omp in the background (e.g. via a Monitor / `run_in_background`) and end the
-   turn. Spawn the Foreman subagent **synchronously** so it returns one complete
-   report. A Foreman that backgrounds omp and goes to rest has not done its job.
-4. **After omp returns, the Director's whole job is verify-and-merge.** Review
+3. **Drive omp without freezing the Director — background it, stay reachable.**
+   The Director (the top-level session) launches `scripts/omp-build` **in the
+   background with its output redirected to a log file**, then returns at once and
+   stays free to talk to the human. The background run wakes the Director when it
+   exits; only then does it verify and review. Redirecting omp's chatter to a log
+   is what keeps the Director's context clean — the job the Foreman used to do —
+   *without* making the Director block. Never run omp so it freezes the Director
+   for the whole build: a long run can outlast the foreground command ceiling, and
+   a blocked Director can't answer the human.
+4. **Whoever launches omp must not end their turn until omp's commit exists.** A
+   subagent gets exactly **one turn**, and its child processes are reaped when it
+   ends — so a Foreman must run omp to completion *within* that turn (foreground-
+   block, or background **and actively wait**, e.g. a Monitor until-loop) and may
+   **never** `run_in_background` and then rest: it will never receive the
+   completion event, and its omp child dies uncommitted. Only the top-level
+   session can safely background a job and be woken later — which is why driving
+   omp from the Director (rule 3) is the default and a Foreman is the exception.
+5. **Verify before declaring done.** Never conclude on a status message ("omp is
+   working autonomously…"). Check `git log` shows a **new omp commit** and
+   `git status` is clean. A clean tree with an unchanged HEAD means omp produced
+   **nothing** — re-drive it; do not report success.
+6. **After omp returns, the Director's whole job is verify-and-merge.** Review
    the committed diff against the original intent and the acceptance criteria,
    run the tests, then push → PR → merge. That's it — don't babysit omp and don't
    rebuild what it already built.
-5. **Watch GitHub; don't poll or interrupt.** Drive on PR events via the
+7. **Watch GitHub; don't poll or interrupt.** Drive on PR events via the
    subscription (CI failures, review comments). Don't busy-poll or sit
    interrupting things while waiting.
 
@@ -106,20 +125,38 @@ These are non-negotiable. Each one cost a botched run before it was written down
 Enforced structurally, not by trust:
 
 1. `omp` is launched (via `scripts/omp-build`) with a local-only `--tools`
-   whitelist — no `github`, `ssh`, `browser`, or `web_search`.
-2. This environment has no `gh` CLI and `omp` is given no push credentials, so
+   whitelist — no dedicated `github`, `ssh`, `browser`, or `web_search` tool.
+2. That whitelist *does* include `bash`, a superset that could otherwise shell
+   out to `ssh` / `git push` / `curl` — so `scripts/omp-build` additionally runs
+   omp under a **scrubbed, throwaway `HOME`** with no SSH credentials and a
+   neutered git-over-ssh. Even a deliberate `bash` attempt has no key to reach
+   prod, so containment holds **regardless of the network policy** (it does not
+   depend on port 22 being firewalled).
+3. This environment has no `gh` CLI and `omp` is given no push credentials, so
    it *cannot* reach GitHub even if it tried.
-3. `omp` runs with `--no-rules --no-extensions`, so it does not ingest this
+4. `omp` runs with `--no-rules --no-extensions`, so it does not ingest this
    repo's `CLAUDE.md` (including the auto-ship authorization) and cannot act on
-   it. Its instructions come only from the spec the Foreman hands it.
+   it. Its instructions come only from the spec the Director (or Foreman) hands it.
 
 ## Invocation
 
-The Foreman invokes `omp` only through the wrapper, never raw:
+The Director (or, optionally, a Foreman) invokes `omp` only through the wrapper,
+never raw:
 
 ```sh
 scripts/omp-build "<spec with acceptance criteria>"
 scripts/omp-build @spec.md
+scripts/omp-build < spec.md          # spec on stdin (most robust for long specs)
+```
+
+**Director default — background it and stay reachable** (rule 3). Run the wrapper
+through the background command runner with its output redirected to a log, so
+omp's chatter never lands in the Director's context and the Director is free to
+keep talking to the human; the run wakes the Director on exit, who then verifies
+the commit (rule 5) and reviews:
+
+```sh
+scripts/omp-build < spec.md > /tmp/omp-run.log 2>&1   # launched in the background
 ```
 
 `scripts/omp-build` bakes in: `--cwd <repo>`, the local-only tool set,

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,58 @@ What's new in Server Assistant. Internal-only updates (CI, dependency bumps, hos
 </style>
 
 <details class="doc-sec" markdown="1" open>
+<summary>v5.6.35 — Polls: a last-chance nudge + a live countdown</summary>
+
+
+Small touches so your community never misses a vote.
+
+### Added
+
+- **⏳ A live countdown on community votes.** A vote now shows a **live countdown** to close ("closes in 2 days, 4 hours") instead of a fixed date — so at a glance everyone knows how long is left.
+- **📣 A "last chance to vote" nudge.** Shortly before a vote closes, Server Assistant posts a gentle last-chance reminder. It **replies to the original poll** so the link is right there — and if that message has scrolled far away or was deleted, it **reposts the poll and carries every existing vote across**, so nobody loses their say and no one can vote twice.
+
+
+</details>
+
+<details class="doc-sec" markdown="1">
+<summary>v5.6.34 — Upload a custom brand icon</summary>
+
+
+### Added
+
+- **🖼️ Upload a custom brand icon in `/brand`.** Premium servers can now attach an image file directly to `/brand` (the new **icon** option) instead of hunting for a public image URL — PNG/JPG/GIF/WebP up to 12 MB. The image is hosted on our side so it never expires, and immediately becomes your white-label embed icon. Pasting a URL still works too.
+
+
+</details>
+
+<details class="doc-sec" markdown="1">
+<summary>v5.6.33 — Native-action notifications, your call</summary>
+
+
+### Added
+
+- **🔕 Turn off "done directly in Discord" notices.** When staff moderate directly in Discord (a native ban/kick/timeout), the bot posts a heads-up in your log channel with a tip for the team. Some servers love it, some find it noisy — so it's now a toggle in **`/settings → 🔔 Notifications`**. On by default; flip it off any time. (Your private, tamper-proof audit log still records every native action regardless.)
+
+
+</details>
+
+<details class="doc-sec" markdown="1">
+<summary>v5.6.32 — Achievements, expanded</summary>
+
+
+### Added
+
+- **🏆 A bigger trophy case.** Server Assistant now tracks far more for your community to earn — new tiered ranks for **Guardian** (AutoMod catches), **Bastion** (raids stopped), **Word of Mouth** (servers that joined through your invite link) and **Patron** (months on Premium), plus a set of one-off **Unique Achievements** (Early Adopter, Setup Complete, First Branding, Loyal Companion, First Catch, Held the Line, Spotless, Trendsetter, Fully Loaded, Welcoming Committee and Phoenix). Each is a hand-designed emblem; everything you'd already earned was unlocked for you automatically — quietly, with no wall of notifications. See it all in your portal's trophy case.
+- **📈 Rising & Buzzing stats** in your portal — members gained in the last 30 days, and your peak activity in the period.
+
+### Changed
+
+- _Achievements got a glow-up:_ the emblems are now tiered hex rank-badges (bronze → silver → gold → diamond), and your server's best in each category sits right in your portal header.
+
+
+</details>
+
+<details class="doc-sec" markdown="1">
 <summary>v5.6.31 — Share your server + milestone badges, in your portal</summary>
 
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1083,6 +1083,11 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
   if (!box) return;
   var API = "https://sa.wandweb.co/api/public/poll-results";
 
+  // Close timestamp of the current active poll (ISO string), or null when no
+  // poll is open / it has closed. Drives the live "closes in 1d 22h" countdown,
+  // kept current by the per-second ticker below between 60s data refreshes.
+  var pollClosesAt = null;
+
   function esc(s) {
     return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
   }
@@ -1183,17 +1188,46 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
         });
       }
     });
-    var closes = "";
-    if (p.status === "active" && p.closes_at) {
-      var d = new Date(p.closes_at);
-      if (!isNaN(d)) closes = " · closes " + d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-    }
+    // Remember this poll's close time so the 1s ticker can keep the countdown
+    // live between the (60s) data refreshes.
+    pollClosesAt = (p.status === "active" && p.closes_at) ? p.closes_at : null;
     var meta = box.querySelector("#lp-meta");
-    if (meta) meta.textContent =
-      total + " votes · " + (p.servers || 0) + " server" + (p.servers === 1 ? "" : "s") + closes +
-      (p.status === "active"
-        ? " · 🟢 live — vote from your server's staff chat; every staff member has a voice"
-        : " · ✅ closed — thank you!");
+    if (meta) {
+      // The vote/server counts come from the data refresh; the close countdown
+      // is its own span so the per-second ticker can update only that part.
+      meta.innerHTML =
+        esc(total + " votes · " + (p.servers || 0) + " server" + (p.servers === 1 ? "" : "s")) +
+        '<span id="lp-closes"></span>' +
+        (p.status === "active"
+          ? " · 🟢 live — vote from your server's staff chat; every staff member has a voice"
+          : " · ✅ closed — thank you!");
+      tickCloseCountdown();
+    }
+  }
+
+  // Live countdown to the poll close, e.g. " · closes in 1d 22h", recomputed on
+  // each tick from the close timestamp. Shows " · voting closed" once the close
+  // time has passed; renders nothing when there's no active close time.
+  function formatCountdown(closesAt) {
+    if (!closesAt) return "";
+    var d = new Date(closesAt);
+    if (isNaN(d)) return "";
+    var ms = d.getTime() - Date.now();
+    if (ms <= 0) return " · voting closed";
+    var totalMin = Math.floor(ms / 60000);
+    var days = Math.floor(totalMin / 1440);
+    var hours = Math.floor((totalMin % 1440) / 60);
+    var mins = totalMin % 60;
+    var parts;
+    if (days > 0) parts = days + "d " + hours + "h";
+    else if (hours > 0) parts = hours + "h " + mins + "m";
+    else parts = mins + "m";
+    return " · closes in " + parts;
+  }
+
+  function tickCloseCountdown() {
+    var el = document.getElementById("lp-closes");
+    if (el) el.textContent = formatCountdown(pollClosesAt);
   }
 
   function renderBands(t, total, nAnswers) {
@@ -1286,8 +1320,10 @@ What ships is what gets requested most clearly. Vague *"add more features"* feed
     setTimeout(function () { refresh(); schedule(); }, nextRefreshAt - Date.now());
   }
 
-  // Visible countdown to the next data refresh, ticking every second
+  // Visible countdown to the next data refresh + the live poll-close countdown,
+  // both ticking every second.
   setInterval(function () {
+    tickCloseCountdown();
     var el = document.getElementById("lp-refresh");
     if (!el) return;
     var s = Math.max(0, Math.ceil((nextRefreshAt - Date.now()) / 1000));

--- a/roadmap.md
+++ b/roadmap.md
@@ -394,7 +394,12 @@ details.safeguards li { margin-bottom: 0.2rem; }
    ════════════════════════════════════════════════════════════════════════ */
 .roadmap-hero { background: rgba(46, 204, 113, 0.10); border-left-color: #2ecc71; color: #e6e9f0; }
 .lp-q { color: #e6e9f0; }
-.lp-label a { color: #cdd4e3; }
+.lp-label a,
+.lp-label a:link,
+.lp-label a:visited,
+.lp-label a:hover,
+.lp-label a:focus,
+.lp-label a:active { color: #fff; }
 .lp-track { background: rgba(255, 255, 255, 0.12); height: 16px; }
 .lp-fill { background: linear-gradient(90deg, #6c3483, #a569bd); }
 .lp-fill.gold { background: linear-gradient(90deg, #b7950b, #f1c40f); }

--- a/scripts/omp-build
+++ b/scripts/omp-build
@@ -30,6 +30,31 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -n "${OMP_ANTHROPIC_API_KEY:-}" ]; then
   export ANTHROPIC_API_KEY="$OMP_ANTHROPIC_API_KEY"
 fi
 
+# ── Containment: deny omp any path off the box ───────────────────────────────
+# omp is granted `bash`, so its "no ssh/github/web" boundary cannot rely on the
+# tool allow-list alone — a bash-capable agent could call `ssh` / `git push`
+# directly. Run omp under a scrubbed, throwaway HOME that carries NO SSH
+# credentials and a neutered git-over-ssh, so even a deliberate attempt has no
+# key to reach prod (e.g. the `hetzner_bot` key the env may drop in the real
+# ~/.ssh). Containment then holds regardless of the network policy — it no longer
+# depends on port 22 being firewalled. The Director still owns everything that
+# crosses the boundary (push, PR, merge).
+_omp_git_name="$(git config --get user.name 2>/dev/null || echo oh-my-pi)"
+_omp_git_email="$(git config --get user.email 2>/dev/null || echo noreply@anthropic.com)"
+OMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$OMP_HOME"' EXIT
+export HOME="$OMP_HOME"
+# Minimal git identity so omp can still commit locally (its expected outcome),
+# without inheriting any credential helper / token / url-rewrite from the real
+# home that could let a commit reach a remote.
+git config --global user.name  "$_omp_git_name"  >/dev/null
+git config --global user.email "$_omp_git_email" >/dev/null
+git config --global commit.gpgsign false         >/dev/null
+# No SSH identity, no agent, strict host checking: both git-over-ssh and a raw
+# `ssh` have nothing to authenticate with.
+export GIT_SSH_COMMAND='ssh -o IdentitiesOnly=yes -o IdentityFile=/dev/null -o IdentityAgent=none -o StrictHostKeyChecking=yes'
+unset SSH_AUTH_SOCK
+
 # Repo root, so omp is scoped correctly no matter where this is invoked from.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 


### PR DESCRIPTION
## Changelog backfill (customer-facing — please eyeball the copy)

The public changelog had drifted: last entry was **v5.6.31**, but the bot is at **5.6.36**. This adds the four genuinely customer-facing releases that were missing, written from the verified commit history + the already-customer-voiced internal CHANGELOG:

- **v5.6.35** — Polls: a last-chance nudge + a live countdown
- **v5.6.34** — Upload a custom brand icon in `/brand`
- **v5.6.33** — Native-action notifications, your call (toggle)
- **v5.6.32** — Achievements, expanded

**v5.6.36** (the version that triggered the errant broadcast) was an **internal-only crash fix** and stays unlisted, per the changelog's own "internal-only updates aren't listed" policy. The companion sa-relay PR makes the autonomous broadcast gate on this changelog, so such internal deploys go silent going forward.

## omp pipeline memory (docs)

- **CLAUDE.md / OMP.md** — omp pipeline rework (Director-drives-backgrounded-default, read-skills-once, scrubbed-HOME containment), matching the other repos.
- **`scripts/omp-build`** — scrubbed-HOME containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM)_