### PR TITLE
Features hero: reword subhead to point at the full feature list

### DIFF
--- a/features.md
+++ b/features.md
@@ -55,7 +55,10 @@ Each feature area pairs what you get **free** (the <span style="color:#3cc1f0;fo
 /* Premium highlight hero — full-width, above the comparison grid. */
 .prem-hero { margin: 1.4rem 0 1rem; border-radius: 16px; padding: .6rem 1.15rem 1.1rem; background: linear-gradient(135deg, rgba(245,196,34,0.16), rgba(245,196,34,0.06) 60%, rgba(20,25,39,0.30)); border: 1px solid rgba(245,196,34,0.42); box-shadow: inset 0 0 0 1px rgba(255,221,128,0.08), 0 10px 30px rgba(90,70,10,0.25); }
 .prem-hero-head { text-align: center; margin-bottom: .9rem; }
-.prem-hero-head h2 { margin: 0 0 .2rem; font-size: 1.4rem; color: var(--ink); border: 0; padding: 0; }
+/* .page-content prefix lifts specificity over glass.css's `.page-content h2`
+   (margin-top:1.8rem; padding-top:.4rem) — it's loaded later in the footer, so an
+   equal-specificity override would lose on source order and leave a gap above the heading. */
+.page-content .prem-hero-head h2 { margin: 0 0 .2rem; font-size: 1.4rem; color: var(--ink); border: 0; padding: 0; }
 .prem-hero-head p { margin: 0 auto; max-width: 46rem; color: var(--ink-soft); font-size: .9rem; }
 .prem-hero-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: .7rem; }
 .ph-card { background: rgba(255,255,255,0.06); border: 1px solid rgba(245,196,34,0.28); border-radius: 12px; padding: .8rem .85rem; }

--- a/features.md
+++ b/features.md
@@ -74,7 +74,7 @@ Each feature area pairs what you get **free** (the <span style="color:#3cc1f0;fo
 <div class="prem-hero" markdown="0">
   <div class="prem-hero-head">
     <h2>Unlock the full toolkit</h2>
-    <p>Three of the upgrades teams love most — plus 750K AI tokens a month.</p>
+    <p>Get these three popular Premium features, 750K AI tokens a month, plus everything else listed below.</p>
   </div>
   <div class="prem-hero-grid">
     <div class="ph-card">


### PR DESCRIPTION
Rewords the Premium hero subhead on the Features page.

**Before:** "Three of the upgrades teams love most — plus 750K AI tokens a month."

**After:** "Get these three popular Premium features, 750K AI tokens a month, plus everything else listed below."

The new copy points readers at the full free-vs-Premium comparison grid below the hero. (Tidied the originally-suggested "+ Everything else listed bellow" into clean prose and fixed the spelling.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PX1pDbqzZpfgnNhL7HKuJz)_