### PR TITLE
docs(changelog): add public v5.6.38 entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,15 @@ What's new in Server Assistant. Internal-only updates (CI, dependency bumps, hos
 </style>
 
 <details class="doc-sec" markdown="1" open>
+<summary>v5.6.38 — Asking the bot to post a message now reliably sends it</summary>
+
+
+When you told the bot in plain language to post something — e.g. "say hello in the lounge" — it could acknowledge the request without the message actually going out, or post its own paraphrase instead of your words, sometimes in the wrong channel. The bot now sends exactly what you asked, finds the channel by name (#lounge, "lounge", or "the lounge channel" all work), and tells you if it can't find the channel or has nothing to send.
+
+
+</details>
+
+<details class="doc-sec" markdown="1">
 <summary>v5.6.36 — Stability & reliability</summary>
 
 


### PR DESCRIPTION
Adds the customer-facing changelog entry for **v5.6.38** so the live page (https://wandweb2.github.io/server-assistant-docs/changelog/) shows the literal `v5.6.38` token. The bot deploy is gated on this — `deploy-bot.sh` polls the rendered changelog and refuses to deploy until the entry is live.

The entry covers the v5.6.38 bot fix in customer language: asking the bot in plain language to post a message (e.g. "say hello in the lounge") now reliably sends exactly what was asked, resolves the channel by name, and reports if it can't find the channel or has nothing to send.

Matches the existing `<details class="doc-sec">` format and newest-first ordering; the new entry takes the `open` attribute previously on v5.6.36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PR36ArwSL92BQkW2fnLD9

---
_Generated by [Claude Code](https://claude.ai/code/session_019PR36ArwSL92BQkW2fnLD9)_