### PR TITLE
docs: lock threat-network participation decisions + background-agent rule

### DIFF
--- a/.omp/threat-score-dossier-spec.md
+++ b/.omp/threat-score-dossier-spec.md
@@ -136,19 +136,37 @@ it already spans the fleet and has sqlite. Proposed split:
 - **P3 — (deferred) action assist:** optional, server-defined thresholds → *suggest* (DM
   check-ins / raid-alert weighting), still never silent auto-bans. Separate spec + safeguards.
 
-## 9. Open decisions (need owner call)
+## 9. Decisions (LOCKED)
 
-- **A. Participation default.** **DECIDED → default-on for every server, with opt-out**
-  (owner: "strongest for all under our wing" + the strengthen-SA principle). This carries the
-  heaviest disclosure/consent burden, so it makes P0 (privacy + terms + prominent disclosure +
-  easy opt-out, advisory-only) a hard blocking dependency. Remaining sub-question: is opt-out
-  per-server only, or also a per-user (data-subject) suppression?
-- **B. Free vs Premium.** Advisory Threat Score is marketed "free for every server"
-  (features.md:170) yet listed under Premium unlocks in the relay (relay.py:5576). Resolve
-  before the dossier ships — the network is most valuable when *every* server participates,
-  which argues for the contribution layer being free/standard even if the rich dossier view
-  is Premium.
-- **C. Which signals cross the boundary.** Start minimal (bans/kicks + serious-category
+These were open owner calls; they are now settled. Do not re-litigate without an
+explicit owner reversal.
+
+1. **No server opt-out.** Participation is **default-on for every server with NO
+   opt-out** — the network is **core functionality**, not a toggle. Every server
+   contributes. (Owner: "strongest for all under our wing" + the strengthen-SA
+   principle.) This carries the heaviest disclosure/consent burden, so it makes
+   P0 (privacy + terms + prominent disclosure, advisory-only) a hard blocking
+   dependency.
+2. **Individual erasure/objection is case-by-case via `/support`** — there is no
+   opt-out UI. A data subject's erasure or objection request is handled
+   individually and either **honoured or refused with documented compelling
+   legitimate grounds** for refusal.
+3. **Retention: 12 months rolling from the last signal → hard-delete.** Each
+   contribution's clock resets on a new signal for that subject; once 12 months
+   elapse with no new signal, the record is hard-deleted.
+4. **Legal basis = legitimate interest, backed by a written LIA**
+   (Legitimate Interests Assessment).
+5. **All servers contribute; the rich dossier view is Premium.** The contribution
+   layer is free/standard (every server participates so the network is maximally
+   valuable); the detailed dossier surface is a Premium feature.
+
+**Legal documentation.** The P0 legal documentation is drafted in **PR #130**
+(`privacy.md` + `terms.md`). The written **LIA** lives at
+`.omp/threat-network-LIA.md`.
+
+### Remaining open (non-blocking)
+
+- **Which signals cross the boundary.** Start minimal (bans/kicks + serious-category
   AutoMod + AltGuard match) and expand; confirm the v1 set.
 
 ## 10. Risks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,12 @@ from the old pipeline and still matter:
   durable, write it back into a skill so it never has to be learned again.
 - **Keep the session free.** Delegate broad research to subagents rather than
   reading large files into the main context.
+
+## Background agents — hygiene (standing rule)
+
+Subagents and background tasks are easy to leak. A prior session left **13 research agents running for 10–22h**, quietly burning tokens, because they were spawned and never reaped. To prevent recurrence:
+
+- **Bound every background/research agent with a finite, focused task** (and a timeout where the tool allows) — never an open-ended "research X" that can loop indefinitely. Prefer one focused agent over a large parallel swarm.
+- **Reap on completion.** When the work is done, confirm no background tasks are still running and stop any straggler. Never end a session with live background agents you no longer need.
+- **If something feels slow, check `/tasks` (or the Background tasks panel).** A task running far longer than its work warrants is stuck — kill it and redo the work directly.
+- Tasks spawned in an earlier context may not be stoppable from a later one programmatically; the operator can stop them from the `/tasks` panel.


### PR DESCRIPTION
Internal documentation only.

- `threat-score-dossier-spec.md`: correct the stale participation default to the LOCKED decision (**default-on, NO server opt-out — core functionality**), and add a **Decisions (LOCKED)** block: case-by-case erasure/objection via `/support` (honoured or refused with documented compelling legitimate grounds), 12-month rolling retention → hard-delete, legitimate-interest basis backed by a written LIA, all-servers-contribute / Premium dossier view. Pointer to PR #130 (privacy.md + terms.md) and the LIA at `.omp/threat-network-LIA.md`.
- Standing background-agent hygiene rule appended to `CLAUDE.md`.

Note: opened on a NEW branch `claude/house-rules-6nhdt3` to avoid the held legal PR #130's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM)_