### PR TITLE
docs(changelog): note portal sign-in reliability fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,15 @@ What's new in Server Assistant. Internal-only updates (CI, dependency bumps, hos
 .doc-sec.tempered .tg-badge { display: inline-block; font-size: .6rem; font-weight: 800; letter-spacing: .09em; text-transform: uppercase; color: #0a1030; background: linear-gradient(135deg, #bcd6ff, #60a5fa); padding: .1rem .45rem; border-radius: 999px; margin-left: .55rem; vertical-align: middle; }
 </style>
 
+<details class="doc-sec" markdown="1">
+<summary>Portal sign-in reliability fix</summary>
+
+
+Fixed an issue where signing in to the web dashboard could show **"Invalid or expired state. Try again"** — most often on mobile, or after refreshing or tapping back during sign-in — even though the sign-in had actually gone through. Signing in is now reliable: open the portal and you're straight in.
+
+
+</details>
+
 <details class="doc-sec" markdown="1" open>
 <summary>v5.6.50 — A full trial on our best AI, then AI that keeps working</summary>
 


### PR DESCRIPTION
Customer-facing changelog entry for the relay OAuth hotfix (**sa-relay#65**, merged).

Portal sign-in could show **"Invalid or expired state. Try again"** — on mobile, or after a refresh / back-button during sign-in — even when auth had actually succeeded. The relay now redeems the OAuth state idempotently, so sign-in is reliable.

**Version-less card** — no `BOT_VERSION` changed (this is a relay/portal fix, not a bot release), so it doesn't take a `vX.Y.Z` heading. It gives the customer-facing **back-online Service Notice** a changelog target to link to. Easy to retitle if you'd prefer a different convention for relay-side customer fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXGuZQqKCkZWXHUypxfJFM)_