### PR TITLE
Wiki: scaffolding + /setup wizard section (Phase 1)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ header_pages:
   - pricing.md
   - compare.md
   - roadmap.md
+  - wiki/index.md
   - portal.md
 
 # Pretty URLs: /privacy/ instead of /privacy.html

--- a/_data/wiki.yml
+++ b/_data/wiki.yml
@@ -1,0 +1,24 @@
+# ============================================================================
+# Server Assistant Wiki — sidebar navigation (single source of truth).
+#
+# This drives the wiki sidebar (rendered in _layouts/wiki.html) and the order
+# pages appear in. Add a page here when you create it under /wiki/.
+#
+#   categories:
+#     - title:  group heading shown in the sidebar
+#       icon:   optional emoji shown before the heading
+#       items:
+#         - label:   link text
+#           url:     the page's permalink (must match the page front matter)
+#           premium: true   # optional — shows a small PREMIUM tag
+#
+# Only list pages that actually exist — every url here renders as a link, so a
+# url with no page behind it is a broken link. The wiki is built in phases
+# (one category per PR); each phase appends its group(s) here.
+# ============================================================================
+categories:
+  - title: Getting started
+    icon: "🚀"
+    items:
+      - { label: "Wiki home", url: "/wiki/" }
+      - { label: "The /setup wizard", url: "/wiki/setup/" }

--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -1,0 +1,57 @@
+---
+layout: default
+---
+{%- comment -%}
+  Wiki layout — a two-column reference shell (category sidebar + content) layered
+  on top of Minima's `default` layout, so the site top-bar and footer stay
+  identical to the rest of the docs. Sidebar order is driven by _data/wiki.yml;
+  search + the wizard step-through come from assets/js/wiki.js. Pages opt in with
+  `layout: wiki` and `wiki: true` front matter (see any page under /wiki/).
+{%- endcomment -%}
+
+<link rel="stylesheet" href="{{ '/assets/css/wiki.css' | relative_url }}?v={{ site.time | date: '%s' }}">
+
+<div class="wiki-shell">
+
+  <input type="checkbox" id="wiki-nav-toggle" class="wiki-nav-toggle" hidden>
+  <label for="wiki-nav-toggle" class="wiki-nav-open" aria-label="Open wiki menu">☰ Wiki menu</label>
+
+  <aside class="wiki-side" aria-label="Wiki navigation">
+    <form class="wiki-search" role="search" onsubmit="return false;">
+      <input type="search" id="wiki-search-input" class="wiki-search-input"
+             placeholder="Search the wiki…" autocomplete="off"
+             aria-label="Search the wiki" aria-controls="wiki-search-results">
+      <ul id="wiki-search-results" class="wiki-search-results" hidden></ul>
+    </form>
+
+    <nav class="wiki-nav">
+      {%- for cat in site.data.wiki.categories -%}
+      <div class="wiki-nav-group">
+        <div class="wiki-nav-title">{% if cat.icon %}<span class="wiki-nav-ic">{{ cat.icon }}</span>{% endif %}{{ cat.title }}</div>
+        <ul>
+          {%- for item in cat.items -%}
+          {%- assign item_url = item.url | relative_url -%}
+          <li><a href="{{ item_url }}"{% if page.url == item.url %} class="active" aria-current="page"{% endif %}>{{ item.label }}{% if item.premium %} <span class="wiki-prem" title="Premium feature">PREMIUM</span>{% endif %}</a></li>
+          {%- endfor -%}
+        </ul>
+      </div>
+      {%- endfor -%}
+    </nav>
+  </aside>
+
+  <main class="wiki-main">
+    {%- if page.wiki_category -%}
+    <div class="wiki-crumbs"><a href="{{ '/wiki/' | relative_url }}">Wiki</a> <span>›</span> {{ page.wiki_category }}</div>
+    {%- endif -%}
+
+    {{ content }}
+
+    <div class="wiki-foot-nav">
+      <a href="{{ '/wiki/' | relative_url }}" class="wiki-foot-home">← Wiki home</a>
+      <a href="https://github.com/{{ site.repository }}/edit/main/{{ page.path }}" class="wiki-foot-edit" rel="nofollow">Suggest an edit</a>
+    </div>
+  </main>
+
+</div>
+
+<script src="{{ '/assets/js/wiki.js' | relative_url }}?v={{ site.time | date: '%s' }}" defer></script>

--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -1,0 +1,208 @@
+/* ============================================================================
+   Server Assistant Wiki — layout + components.
+   Layered on top of tokens.css + glass.css (loaded site-wide via the footer).
+   Adds: the two-column wiki shell (sidebar + content), search, the wizard
+   step-through widget, command reference cards, and a few extra Discord-mockup
+   primitives (dropdowns, modals) that extend the shared .dc-* system.
+   ============================================================================ */
+
+/* ── Shell ──────────────────────────────────────────────────────────────── */
+.wiki-shell {
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+  gap: 2.4rem;
+  align-items: start;
+}
+.wiki-main { min-width: 0; }
+
+/* ── Sidebar ────────────────────────────────────────────────────────────── */
+.wiki-side {
+  position: sticky;
+  top: 72px;
+  align-self: start;
+  max-height: calc(100vh - 88px);
+  overflow-y: auto;
+  padding-right: .4rem;
+  font-size: .9rem;
+}
+.wiki-nav-group { margin-bottom: 1.25rem; }
+.wiki-nav-title {
+  display: flex; align-items: center; gap: .45rem;
+  font-size: .72rem; font-weight: 800; letter-spacing: .06em; text-transform: uppercase;
+  color: var(--fg-2); margin: 0 0 .5rem;
+}
+.wiki-nav-ic { font-size: .95rem; }
+.wiki-nav ul { list-style: none; margin: 0; padding: 0; }
+.wiki-nav li { margin: 0; }
+.wiki-nav a {
+  display: flex; align-items: center; gap: .4rem;
+  padding: .34rem .6rem; border-radius: 8px;
+  color: var(--fg-1); text-decoration: none; line-height: 1.3;
+  border-left: 2px solid transparent;
+}
+.wiki-nav a:hover { background: var(--surface); color: var(--fg-0); }
+.wiki-nav a.active {
+  background: var(--accent-soft); color: var(--fg-0); font-weight: 600;
+  border-left-color: var(--accent);
+}
+
+/* ── Search ─────────────────────────────────────────────────────────────── */
+.wiki-search { position: relative; margin-bottom: 1.4rem; }
+.wiki-search-input {
+  width: 100%; box-sizing: border-box;
+  padding: .55rem .7rem; border-radius: 10px;
+  background: var(--surface); border: 1px solid var(--border);
+  color: var(--fg-0); font-size: .9rem; font-family: inherit;
+}
+.wiki-search-input::placeholder { color: var(--fg-2); }
+.wiki-search-input:focus { outline: none; border-color: var(--accent); background: var(--surface-2); }
+.wiki-search-results {
+  position: absolute; z-index: 30; left: 0; right: 0; top: calc(100% + .35rem);
+  list-style: none; margin: 0; padding: .3rem;
+  background: var(--glass-strong); border: 1px solid var(--border); border-radius: 12px;
+  box-shadow: var(--shadow);
+  -webkit-backdrop-filter: blur(14px); backdrop-filter: blur(14px);
+  max-height: 60vh; overflow-y: auto;
+}
+.wiki-search-results li { margin: 0; }
+.wiki-search-results a {
+  display: flex; flex-direction: column; gap: .1rem;
+  padding: .45rem .55rem; border-radius: 8px; text-decoration: none;
+}
+.wiki-search-results a:hover { background: var(--surface-2); }
+.wiki-sr-title { color: var(--fg-0); font-weight: 600; font-size: .88rem; }
+.wiki-sr-cat   { color: var(--fg-2); font-size: .72rem; }
+.wiki-sr-empty { padding: .5rem .55rem; color: var(--fg-2); font-size: .85rem; }
+
+/* ── Sidebar toggle (mobile only) ───────────────────────────────────────── */
+.wiki-nav-open {
+  display: none;
+  margin: 0 0 1rem; padding: .5rem .85rem; border-radius: 10px; cursor: pointer;
+  background: var(--surface); border: 1px solid var(--border); color: var(--fg-0);
+  font-weight: 600; font-size: .9rem; width: max-content;
+}
+
+/* ── Breadcrumbs + footer nav ───────────────────────────────────────────── */
+.wiki-crumbs { font-size: .8rem; color: var(--fg-2); margin-bottom: .4rem; }
+.wiki-crumbs a { color: var(--fg-1); text-decoration: none; }
+.wiki-crumbs a:hover { color: var(--accent); }
+.wiki-crumbs span { margin: 0 .3rem; opacity: .6; }
+.wiki-foot-nav {
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 1rem;
+  margin-top: 3rem; padding-top: 1.2rem; border-top: 1px solid var(--divider);
+  font-size: .88rem;
+}
+.wiki-foot-nav a { text-decoration: none; color: var(--fg-1); }
+.wiki-foot-nav a:hover { color: var(--accent); }
+
+/* ── Premium tag ────────────────────────────────────────────────────────── */
+.wiki-prem {
+  font-size: .56rem; font-weight: 800; letter-spacing: .05em;
+  padding: .06rem .3rem; border-radius: 4px; vertical-align: middle;
+  background: var(--gold-soft); color: var(--gold); border: 1px solid rgba(245,196,34,.35);
+}
+
+/* ── Wizard step-through ────────────────────────────────────────────────── */
+.wiz {
+  border: 1px solid var(--border); border-radius: var(--r-md);
+  background: var(--glass-panel); padding: 1rem; margin: 1.4rem 0;
+  -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px);
+}
+.wiz-bar {
+  display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
+  margin-bottom: .85rem; padding-bottom: .75rem; border-bottom: 1px solid var(--divider);
+}
+.wiz-label { font-weight: 700; color: var(--fg-0); flex: 1 1 auto; min-width: 0; }
+.wiz-counter { font-size: .78rem; color: var(--fg-2); font-variant-numeric: tabular-nums; }
+.wiz-btn {
+  font: inherit; font-size: .82rem; font-weight: 600; cursor: pointer;
+  padding: .32rem .7rem; border-radius: 8px;
+  background: var(--surface-2); border: 1px solid var(--border); color: var(--fg-0);
+}
+.wiz-btn:hover:not(:disabled) { background: var(--surface-hi); }
+.wiz-btn:disabled { opacity: .4; cursor: default; }
+.wiz-dots { display: flex; gap: .35rem; }
+.wiz-dot {
+  width: 9px; height: 9px; padding: 0; border-radius: 50%; cursor: pointer;
+  background: var(--surface-hi); border: none;
+}
+.wiz-dot.on { background: var(--accent); }
+/* Default (no-JS): every step stacked + visible, each with its label shown. */
+.wiz-step { margin: 0 0 1rem; }
+.wiz-step::before {
+  content: attr(data-step); display: block; margin-bottom: .4rem;
+  font-size: .74rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.wiz-step:last-child { margin-bottom: 0; }
+/* Enhanced (JS on): show one step at a time; labels move into the top bar. */
+.wiz-ready .wiz-step { display: none; }
+.wiz-ready .wiz-step.on { display: block; }
+.wiz-ready .wiz-step { margin: 0; }
+.wiz-ready .wiz-step::before { display: none; }
+.wiz-caption { margin-top: .7rem; color: var(--fg-1); font-size: .9rem; line-height: 1.55; }
+
+/* ── Command reference card ─────────────────────────────────────────────── */
+.cmd-card {
+  border: 1px solid var(--border); border-radius: var(--r-md);
+  background: var(--surface); padding: 1.1rem 1.25rem; margin: 1.3rem 0;
+}
+.cmd-head { display: flex; align-items: center; flex-wrap: wrap; gap: .5rem .7rem; }
+.cmd-name {
+  font-family: Consolas, "SF Mono", Menlo, monospace; font-weight: 700; font-size: 1.08rem;
+  color: var(--fg-0); background: #1e1f22; padding: .18rem .5rem; border-radius: 6px;
+}
+.cmd-tag {
+  font-size: .66rem; font-weight: 800; letter-spacing: .04em; text-transform: uppercase;
+  padding: .12rem .42rem; border-radius: 5px; border: 1px solid var(--border); color: var(--fg-1);
+}
+.cmd-tag.free    { background: rgba(84,224,142,.12); color: var(--ok);   border-color: rgba(84,224,142,.3); }
+.cmd-tag.premium { background: var(--gold-soft);     color: var(--gold); border-color: rgba(245,196,34,.35); }
+.cmd-tag.perm    { background: rgba(255,148,102,.12); color: var(--high); border-color: rgba(255,148,102,.3); }
+.cmd-tag.ai      { background: var(--pink-soft);      color: var(--pink); border-color: rgba(238,91,162,.3); }
+.cmd-desc { color: var(--fg-1); margin: .55rem 0 0; line-height: 1.55; }
+.cmd-args { width: 100%; border-collapse: collapse; margin: .9rem 0 0; font-size: .88rem; }
+.cmd-args th, .cmd-args td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid var(--divider); vertical-align: top; }
+.cmd-args th { color: var(--fg-2); font-size: .74rem; text-transform: uppercase; letter-spacing: .04em; }
+.cmd-args code { color: var(--accent); }
+.cmd-args .req { color: var(--high); font-size: .72rem; font-weight: 700; }
+.cmd-args .opt { color: var(--fg-2); font-size: .72rem; }
+
+/* ── Discord-mockup extensions (build on glass.css .dc-*) ───────────────── */
+/* A slash-command invocation line (what the user types). */
+.dc-slash { color: #b5bac1; }
+.dc-slash .cmd { color: #5865f2; font-weight: 600; }
+.dc-slash .arg { color: #00a8fc; }
+/* A select / dropdown component. */
+.dc-select {
+  display: flex; justify-content: space-between; align-items: center;
+  background: #1e1f22; border: 1px solid #232428; border-radius: 4px;
+  padding: .4rem .6rem; margin-top: .55rem; color: #b5bac1; font-size: .8rem;
+}
+.dc-select::after { content: "▾"; color: #949ba4; }
+/* A modal form (the pop-up dialogs). */
+.dc-modal {
+  background: #313338; border-radius: 8px; padding: .85rem .9rem; margin-top: .15rem;
+  border: 1px solid #232428; max-width: 360px;
+}
+.dc-modal-title { font-weight: 700; color: #f2f3f5; margin-bottom: .15rem; }
+.dc-modal-sub   { color: #949ba4; font-size: .72rem; margin-bottom: .6rem; }
+.dc-flabel { font-size: .68rem; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; color: #b5bac1; margin: .5rem 0 .2rem; }
+.dc-input {
+  background: #1e1f22; border: 1px solid #1e1f22; border-radius: 4px;
+  padding: .4rem .55rem; color: #dbdee1; font-size: .8rem; min-height: 1.1rem;
+}
+.dc-input.ph { color: #6d7178; }
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+@media screen and (max-width: 880px) {
+  .wiki-shell { grid-template-columns: 1fr; gap: 1rem; }
+  .wiki-nav-open { display: block; }
+  .wiki-side {
+    position: static; max-height: none; overflow: visible;
+    display: none;
+    margin-bottom: 1rem; padding: 1rem;
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md);
+  }
+  .wiki-nav-toggle:checked ~ .wiki-side { display: block; }
+}

--- a/assets/js/wiki.js
+++ b/assets/js/wiki.js
@@ -1,0 +1,160 @@
+/* ============================================================================
+   Server Assistant Wiki — client behaviour (no external dependencies).
+     1. Search   — a tiny token-scored search over /wiki/search.json.
+     2. Stepper  — turns [data-wiz] blocks into a clickable step-through so a
+                   multi-screen wizard can be walked one state at a time.
+   Both are progressive enhancements: with JS off, search is simply absent and
+   every wizard state renders stacked and fully visible.
+   ============================================================================ */
+(function () {
+  "use strict";
+
+  /* ---- 1. Search --------------------------------------------------------- */
+  (function search() {
+    var input = document.getElementById("wiki-search-input");
+    var list  = document.getElementById("wiki-search-results");
+    if (!input || !list) return;
+
+    var index = null, loading = false;
+
+    // Resolve /wiki/search.json against the site baseurl by reading it off the
+    // input's own page URL prefix (everything up to "/wiki/").
+    function indexUrl() {
+      var p = window.location.pathname;
+      var i = p.indexOf("/wiki/");
+      var base = i >= 0 ? p.slice(0, i) : "";
+      return base + "/wiki/search.json";
+    }
+
+    function load() {
+      if (index || loading) return;
+      loading = true;
+      fetch(indexUrl())
+        .then(function (r) { return r.ok ? r.json() : []; })
+        .then(function (data) { index = data || []; render(input.value); })
+        .catch(function () { index = []; });
+    }
+
+    function esc(s) {
+      return String(s).replace(/[&<>"]/g, function (c) {
+        return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+      });
+    }
+
+    function score(entry, terms) {
+      var hay = {
+        title:    (entry.title || "").toLowerCase(),
+        keywords: (Array.isArray(entry.keywords) ? entry.keywords.join(" ") : (entry.keywords || "")).toLowerCase(),
+        category: (entry.category || "").toLowerCase(),
+        summary:  (entry.summary || "").toLowerCase(),
+        body:     (entry.body || "").toLowerCase()
+      };
+      var total = 0;
+      for (var t = 0; t < terms.length; t++) {
+        var term = terms[t], hit = 0;
+        if (hay.title.indexOf(term) >= 0)    hit += 6;
+        if (hay.keywords.indexOf(term) >= 0) hit += 4;
+        if (hay.category.indexOf(term) >= 0) hit += 2;
+        if (hay.summary.indexOf(term) >= 0)  hit += 2;
+        if (hay.body.indexOf(term) >= 0)     hit += 1;
+        if (hit === 0) return 0;        // every term must appear somewhere
+        total += hit;
+      }
+      return total;
+    }
+
+    function render(q) {
+      if (!index) { load(); return; }
+      var query = (q || "").trim().toLowerCase();
+      if (query.length < 2) { hide(); return; }
+      var terms = query.split(/\s+/);
+      var ranked = [];
+      for (var i = 0; i < index.length; i++) {
+        var s = score(index[i], terms);
+        if (s > 0) ranked.push({ s: s, e: index[i] });
+      }
+      ranked.sort(function (a, b) { return b.s - a.s; });
+      ranked = ranked.slice(0, 8);
+
+      if (!ranked.length) {
+        list.innerHTML = '<li class="wiki-sr-empty">No matches for “' + esc(q) + '”</li>';
+        list.hidden = false;
+        return;
+      }
+      var html = "";
+      for (var j = 0; j < ranked.length; j++) {
+        var e = ranked[j].e;
+        html += '<li><a href="' + esc(e.url) + '">' +
+                '<span class="wiki-sr-title">' + esc(e.title) + '</span>' +
+                (e.category ? '<span class="wiki-sr-cat">' + esc(e.category) + '</span>' : "") +
+                '</a></li>';
+      }
+      list.innerHTML = html;
+      list.hidden = false;
+    }
+
+    function hide() { list.hidden = true; list.innerHTML = ""; }
+
+    input.addEventListener("focus", load);
+    input.addEventListener("input", function () { render(input.value); });
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") { input.value = ""; hide(); input.blur(); }
+      if (e.key === "Enter") {
+        var first = list.querySelector("a");
+        if (first) { e.preventDefault(); window.location = first.getAttribute("href"); }
+      }
+    });
+    document.addEventListener("click", function (e) {
+      if (!list.contains(e.target) && e.target !== input) hide();
+    });
+  })();
+
+  /* ---- 2. Wizard step-through -------------------------------------------- */
+  (function stepper() {
+    var wizards = document.querySelectorAll("[data-wiz]");
+    if (!wizards.length) return;
+
+    Array.prototype.forEach.call(wizards, function (wiz) {
+      var steps = wiz.querySelectorAll(".wiz-step");
+      if (steps.length < 2) return;       // nothing to step through
+      wiz.classList.add("wiz-ready");     // CSS switches to single-view mode
+
+      var idx = 0;
+      var label = wiz.querySelector(".wiz-label");
+      var prev  = wiz.querySelector(".wiz-prev");
+      var next  = wiz.querySelector(".wiz-next");
+      var dotsBox = wiz.querySelector(".wiz-dots");
+      var counter = wiz.querySelector(".wiz-counter");
+      var dots = [];
+
+      if (dotsBox) {
+        for (var d = 0; d < steps.length; d++) {
+          var dot = document.createElement("button");
+          dot.type = "button";
+          dot.className = "wiz-dot";
+          dot.setAttribute("aria-label", "Go to step " + (d + 1));
+          (function (n) { dot.addEventListener("click", function () { go(n); }); })(d);
+          dotsBox.appendChild(dot);
+          dots.push(dot);
+        }
+      }
+
+      function go(n) {
+        idx = Math.max(0, Math.min(steps.length - 1, n));
+        for (var i = 0; i < steps.length; i++) {
+          steps[i].classList.toggle("on", i === idx);
+          if (dots[i]) dots[i].classList.toggle("on", i === idx);
+        }
+        if (label) label.textContent = steps[idx].getAttribute("data-step") || "";
+        if (counter) counter.textContent = (idx + 1) + " / " + steps.length;
+        if (prev) prev.disabled = (idx === 0);
+        if (next) next.disabled = (idx === steps.length - 1);
+      }
+
+      if (prev) prev.addEventListener("click", function () { go(idx - 1); });
+      if (next) next.addEventListener("click", function () { go(idx + 1); });
+      go(0);
+    });
+  })();
+
+})();

--- a/search.json
+++ b/search.json
@@ -1,0 +1,18 @@
+---
+permalink: /wiki/search.json
+layout: null
+sitemap: false
+---
+[
+{%- assign wikipages = site.pages | where: "wiki", true -%}
+{%- for p in wikipages -%}
+{
+"title": {{ p.title | remove_first: "Server Assistant " | jsonify }},
+"url": {{ p.url | relative_url | jsonify }},
+"category": {{ p.wiki_category | default: "" | jsonify }},
+"summary": {{ p.summary | default: "" | jsonify }},
+"keywords": {{ p.wiki_keywords | default: "" | jsonify }},
+"body": {{ p.content | strip_html | normalize_whitespace | truncatewords: 120 | jsonify }}
+}{%- unless forloop.last -%},{%- endunless -%}
+{%- endfor -%}
+]

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,79 @@
+---
+layout: wiki
+title: Server Assistant Wiki
+permalink: /wiki/
+wiki: true
+wiki_category: Getting started
+summary: The complete Server Assistant reference — every command, every wizard, and every flow, with live examples of what you'll see in Discord.
+wiki_keywords: [wiki, reference, commands, guide, help, documentation, examples]
+description: The complete Server Assistant reference — every command, wizard and flow, each shown with a live example of what you'll see in Discord.
+---
+
+<style>
+.wiki-hub { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; margin: 1.6rem 0; }
+.wiki-hub .card { display: block; padding: 1.1rem 1.2rem; border-radius: var(--r-md); border: 1px solid var(--border); background: var(--surface); text-decoration: none; transition: transform .12s, border-color .12s, background .12s; }
+.wiki-hub a.card:hover { transform: translateY(-2px); border-color: var(--accent); background: var(--surface-2); }
+.wiki-hub .card h3 { margin: 0 0 .3rem; font-size: 1.04rem; color: var(--fg-0); display: flex; align-items: center; gap: .5rem; }
+.wiki-hub .card p { margin: 0; color: var(--fg-1); font-size: .88rem; line-height: 1.5; }
+.wiki-hub .card.soon { opacity: .62; }
+.wiki-hub .card.soon h3::after { content: "Coming soon"; margin-left: auto; font-size: .58rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; color: var(--fg-2); background: var(--surface-2); padding: .12rem .4rem; border-radius: 5px; }
+.wiki-lead { color: var(--fg-1); font-size: 1.02rem; line-height: 1.6; max-width: 62ch; }
+</style>
+
+# 📖 Server Assistant Wiki
+
+<p class="wiki-lead">The full reference for Server Assistant — <strong>every command, every setup wizard, and every automatic flow</strong>, each shown with a live mock-up of exactly what you'll see in Discord. Search above, or browse by area below.</p>
+
+<div class="wiki-hub">
+
+  <a class="card" href="{{ '/wiki/setup/' | relative_url }}">
+    <h3>🚀 The /setup wizard</h3>
+    <p>Walk through every screen of first-time setup — channels, roles, permissions and AI — one state at a time.</p>
+  </a>
+
+  <div class="card soon">
+    <h3>🛡️ Moderation &amp; safety</h3>
+    <p>Warnings, mutes, bans, lockdown, purge and the anti-raid toolkit — every command with its output.</p>
+  </div>
+
+  <div class="card soon">
+    <h3>⚙️ Settings &amp; dashboards</h3>
+    <p>The Settings hub, AutoMod, onboarding, tickets and every configuration panel.</p>
+  </div>
+
+  <div class="card soon">
+    <h3>🤖 AI &amp; intelligence</h3>
+    <p>SAi chat, image generation, translation, mediation and how AI tiers work.</p>
+  </div>
+
+  <div class="card soon">
+    <h3>🎫 Tickets &amp; support</h3>
+    <p>The ticket panel, intake questions and the full support flow.</p>
+  </div>
+
+  <div class="card soon">
+    <h3>✨ Member experience</h3>
+    <p>Welcome DMs, role panels, verification and the flows new members see.</p>
+  </div>
+
+  <div class="card soon">
+    <h3>💎 Account &amp; premium</h3>
+    <p>Premium status, billing, privacy controls and account commands.</p>
+  </div>
+
+</div>
+
+> **This wiki is growing.** We're adding every command and flow area by area. Live sections are linked above and listed in the sidebar; the rest are on the way.
+
+## How to read the examples
+
+Every screen on this wiki is a faithful recreation of the real Discord interface — the same embeds, buttons and dropdowns you'll see in your server. Where a feature is a multi-step **wizard**, you'll find a step-through like the one on the [setup page]({{ '/wiki/setup/' | relative_url }}): use **Next ›** and **‹ Back** to walk each state.
+
+Commands are tagged so you know what you're looking at:
+
+<span class="cmd-tag free">FREE</span> available on every plan &nbsp;·&nbsp;
+<span class="cmd-tag premium">PREMIUM</span> needs Premium &nbsp;·&nbsp;
+<span class="cmd-tag perm">ADMIN</span> requires a staff role or permission &nbsp;·&nbsp;
+<span class="cmd-tag ai">AI</span> uses AI tokens
+
+<p style="margin-top:2rem;">New here? Start with <a href="{{ '/setup/' | relative_url }}">the quick setup guide</a>, then come back for the full reference.</p>

--- a/wiki/setup.md
+++ b/wiki/setup.md
@@ -1,0 +1,197 @@
+---
+layout: wiki
+title: Server Assistant Setup Wizard
+permalink: /wiki/setup/
+wiki: true
+wiki_category: Getting started
+summary: A screen-by-screen walkthrough of the /setup wizard — preflight checks, channels, roles, permission review, AI and the welcome guide. Step through every state.
+wiki_keywords: [setup, wizard, onboarding, channels, roles, permissions, automod, ai, byok, getting started, configure]
+description: Every screen of the Server Assistant /setup wizard, shown one state at a time exactly as it appears in Discord.
+---
+
+# 🧭 The `/setup` wizard
+
+`/setup` is how Server Assistant gets configured for your server. It's a short,
+guided flow: the bot detects sensible defaults, fills them in for you, and you
+just confirm each screen. The whole thing takes about a minute.
+
+You can reach it three ways:
+
+- **Automatically** — when the bot joins, it DMs the server owner a **Welcome**
+  message that opens the wizard.
+- **`/setup`** — run it in your server any time to re-open the wizard (it
+  pre-fills your *current* configuration, not a blank slate).
+- **Web portal** — every screen has a *“finish setup on the web”* link to
+  [the portal]({{ '/portal/' | relative_url }}) if you'd rather click through a browser.
+
+> **Who can run it:** the server **owner**, or an admin with **Manage Server**.
+
+## Step through every screen
+
+Use **Next ›** and **‹ Back** to walk each state — including the two
+*conditional* screens (Preflight and Permission review) that only appear when the
+bot needs them.
+
+<div class="wiz" data-wiz>
+  <div class="wiz-bar">
+    <span class="wiz-label">Preflight · permission check</span>
+    <span class="wiz-counter"></span>
+    <div class="wiz-dots"></div>
+    <button class="wiz-btn wiz-prev" type="button">‹ Back</button>
+    <button class="wiz-btn wiz-next" type="button">Next ›</button>
+  </div>
+
+  <div class="wiz-step on" data-step="Preflight · permission check">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed amber">
+          <div class="dc-title">⚠️ Before we start — a couple of permissions</div>
+          <div class="dc-desc">I'm missing a permission I need to set things up properly. Grant it and re-check, or continue and I'll do what I can.</div>
+          <div class="dc-fname">Manage Roles</div><div class="dc-fval">❌ Needed to create and assign your staff roles</div>
+          <div class="dc-fname">Manage Channels</div><div class="dc-fval">✓ Granted</div>
+          <div class="dc-btns">
+            <span class="dc-btn grey">🔄 Re-check</span>
+            <span class="dc-btn blurple">Continue anyway →</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Only shows if something's missing.</strong> If the bot already has the permissions it needs, the wizard skips straight to Step 1. “Re-check” re-reads the bot's permissions after you fix them; “Continue anyway” proceeds and the bot does what it can.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Step 1 · Channels">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed blue">
+          <div class="dc-title">🧭 Welcome — let's get you set up</div>
+          <div class="dc-desc">I've filled in your channels and roles. <strong>Step 1 of 3</strong> — looks right?</div>
+          <div class="dc-fname">Staff chat <span style="color:#949ba4;font-weight:400">(where I listen for commands)</span></div><div class="dc-fval">#staff-chat ✓ <span style="color:#949ba4">(detected)</span></div>
+          <div class="dc-fname">Log channel <span style="color:#949ba4;font-weight:400">(your audit trail)</span></div><div class="dc-fval">#mod-log ✓ <span style="color:#949ba4">(detected)</span></div>
+          <div class="dc-select">Pick a different staff chat…</div>
+          <div class="dc-btns">
+            <span class="dc-btn grey">🆕 Create for me</span>
+            <span class="dc-btn green">✅ Looks good →</span>
+          </div>
+          <div class="dc-btns">
+            <span class="dc-btn blurple">🌐 …or finish setup on the web</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Channels.</strong> Pick the <em>staff chat</em> (the command listening post) and a <em>log channel</em> (the audit trail). The bot pre-fills both from what it detected — use the dropdowns to change them, or <strong>🆕 Create for me</strong> to have it make fresh channels. Tags read <code>(detected)</code> on a new server, or <code>(current)</code> if you're re-running setup.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Step 2 · Roles">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed blue">
+          <div class="dc-title">🛡️ Who's on your team?</div>
+          <div class="dc-desc"><strong>Step 2 of 3</strong> — tell me which roles are your admins and moderators so commands respect your hierarchy.</div>
+          <div class="dc-fname">🟥 Admin role</div><div class="dc-fval">@Admin ✓ <span style="color:#949ba4">(detected)</span></div>
+          <div class="dc-fname">🟦 Moderator role</div><div class="dc-fval">@Moderator ✓ <span style="color:#949ba4">(detected)</span></div>
+          <div class="dc-foot">Server owner always has full access — no role needed.</div>
+          <div class="dc-btns">
+            <span class="dc-btn grey">🆕 Create Admin + Mod</span>
+            <span class="dc-btn green">✅ Looks good →</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Roles.</strong> Choose your <em>Admin</em> and <em>Moderator</em> roles — the colour emoji mirrors each role's colour so they're easy to spot. No suitable roles yet? <strong>🆕 Create Admin + Mod</strong> generates them with sensible permissions. The owner is always treated as full-access, so an owner role is optional.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Permission review">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed amber">
+          <div class="dc-title">🔐 Quick permission tidy-up</div>
+          <div class="dc-desc">To make these roles work, I'd like to adjust a few permissions. Nothing happens until you approve.</div>
+          <div class="dc-fname">➕ @Moderator</div><div class="dc-fval">+ Timeout Members, + Manage Messages</div>
+          <div class="dc-fname">➖ @everyone</div><div class="dc-fval">− Mention @everyone <span style="color:#949ba4">(in #staff-chat)</span></div>
+          <div class="dc-btns">
+            <span class="dc-btn green">✅ Approve &amp; apply</span>
+            <span class="dc-btn grey">🆕 Generate fresh instead</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Only shows if a tidy-up is needed.</strong> If your staff roles are missing a permission they need — or <code>@everyone</code> has a risky one — the bot lists the exact change and waits for your <strong>✅ Approve &amp; apply</strong>. If it can't make a change because of role hierarchy, this becomes a <strong>🔄 Re-check</strong> after you move its role up.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Step 3 · AI &amp; community type">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed blue">
+          <div class="dc-title">🎚️ Last step — tune the defaults</div>
+          <div class="dc-desc"><strong>Step 3 of 3.</strong> Pick your community type so I can preset AutoMod, the punishment ladder and anti-raid sensibly — then choose how you'd like AI.</div>
+          <div class="dc-fname">Community type</div>
+          <div class="dc-select">🎮 Gaming</div>
+          <div class="dc-fname">AI features</div>
+          <div class="dc-fval">Start with a free <strong>150k-token trial</strong>, bring your own key, or skip for now.</div>
+          <div class="dc-btns">
+            <span class="dc-btn green">Finish setup ✓</span>
+            <span class="dc-btn blurple">🔑 Enter my own key</span>
+            <span class="dc-btn grey">Skip AI</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>AI &amp; community type.</strong> The bot guesses your <em>community type</em> from your server name and description (Gaming, Creator, Anime, Crypto, Education, DIY and more) and uses it to preset AutoMod, the punishment ladder and anti-raid. Then pick your AI path — the <strong>free trial</strong>, <strong>🔑 your own key</strong> (opens the form on the next screen), or <strong>Skip AI</strong>.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Bring your own key (optional)">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-modal">
+          <div class="dc-modal-title">Use your own AI key</div>
+          <div class="dc-modal-sub">Paste a provider key and you control your own usage and billing.</div>
+          <div class="dc-flabel">API key</div>
+          <div class="dc-input ph">sk-…</div>
+          <div class="dc-btns"><span class="dc-btn blurple">Save</span></div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Only if you chose “Enter my own key”.</strong> Choosing <strong>🔑 Enter my own key</strong> on the previous screen opens this short form. Paste a supported provider key and your server runs AI on your own account — no trial limit. You can change or remove it later with <code>/ai-config</code>.</p>
+  </div>
+
+  <div class="wiz-step" data-step="Setup complete">
+    <div class="dc">
+      <div class="dc-row"><img class="dc-av" src="{{ '/assets/logo.png' | relative_url }}" alt="Server Assistant" loading="lazy"><div class="dc-body">
+        <div class="dc-head"><span class="dc-name">Server Assistant</span><span class="dc-bot">App</span><span class="dc-time">Direct Message</span></div>
+        <div class="dc-embed green">
+          <div class="dc-title">🎉 You're all set!</div>
+          <div class="dc-desc">Server Assistant is configured and watching your server. Here's the summary:</div>
+          <div class="dc-fname">Channels</div><div class="dc-fval">Staff #staff-chat · Logs #mod-log</div>
+          <div class="dc-fname">Roles</div><div class="dc-fval">Admin @Admin · Mod @Moderator</div>
+          <div class="dc-fname">Preset</div><div class="dc-fval">🎮 Gaming · AutoMod on · Anti-raid on</div>
+          <div class="dc-foot">Want your mods to know the ropes? I can post a quick welcome guide to your staff chat.</div>
+          <div class="dc-btns">
+            <span class="dc-btn green">📤 Post welcome to staff chat</span>
+            <span class="dc-btn grey">Skip</span>
+          </div>
+        </div>
+      </div></div>
+    </div>
+    <p class="wiz-caption"><strong>Done.</strong> A recap of everything that was configured. <strong>📤 Post welcome to staff chat</strong> drops a short “how to drive the bot” guide into your staff channel for the rest of your team (on a re-run this becomes <strong>🔁 Re-post</strong>). From here, try <code>/help</code> or open <code>/settings</code> to fine-tune anything.</p>
+  </div>
+</div>
+
+## What if I want to change something later?
+
+Nothing here is one-shot. Re-run **`/setup`** any time — it loads your current
+configuration so you can adjust a single thing without starting over. For
+deeper, per-feature control, open the **Settings hub** with `/settings`, or
+manage AutoMod, onboarding and the rest from their own commands (each gets its
+own page in this wiki).
+
+## See also
+
+- [Quick setup guide]({{ '/setup/' | relative_url }}) — the short marketing walkthrough
+- [Autopilot]({{ '/wiki/' | relative_url }}) — let the bot detect and apply a full config for you *(coming soon)*
+- [Settings hub]({{ '/wiki/' | relative_url }}) — every configuration panel *(coming soon)*


### PR DESCRIPTION
## What this is

Phase 1 of a customer-facing **Wiki** for Server Assistant — a reference that will document **every command, every wizard, and every flow**, each shown with a live Discord-style mock-up (the same hand-coded `.dc-*` approach already used on the docs site). This PR lands the shared foundation plus the **`/setup` wizard** as the proven pattern.

## Plan (agreed up front)

- **Where:** a new `/wiki/` section inside this docs site (not a separate repo). Customer-facing.
- **Look:** a custom glass-themed **sidebar layout** matching the existing theme — not a second Jekyll theme.
- **Content:** every command (full treatment), every wizard/dashboard as a **clickable step-through**, and the automatic flows.
- **Delivery:** phased PRs — this is the scaffolding + setup section; subsequent PRs add one category each.

## What's in this PR

- `_layouts/wiki.html` — two-column wiki shell (category sidebar + content) layered on Minima's `default` layout, so the top bar and footer are unchanged.
- `_data/wiki.yml` — single source of truth for the sidebar; each phase appends its category group here.
- `assets/css/wiki.css` — sidebar, search, the wizard step-through widget, command-reference cards, and Discord-mockup extensions (dropdowns, modals) building on the existing `.dc-*` system.
- `assets/js/wiki.js` — **dependency-free** client search over `/wiki/search.json` and a clickable step-through for `[data-wiz]` blocks. Progressive enhancement: with JS off, search is simply absent and every wizard state renders stacked and fully visible.
- `search.json` — generated search index over any page with `wiki: true` front matter.
- `wiki/index.md` — landing hub with the planned category map.
- `wiki/setup.md` — full `/setup` walkthrough: preflight → channels → roles → permission review → AI & community type → BYOK → completion, each as a step in the step-through.
- One **"Wiki"** link added to the top nav; existing marketing pages left untouched.

## Validation

Built locally with `jekyll build` (Minima + the site's plugins):
- `/wiki/` and `/wiki/setup/` render.
- `/wiki/search.json` is valid JSON (2 entries, correct titles/categories/URLs).
- Sidebar, active-state, breadcrumbs and the 7-state step-through markup all present.

## Next phases

One PR per category — Moderation & safety, Settings & dashboards, AI & intelligence, Tickets, Member experience, Account & premium — built by parallel agents that read the relevant `bot.py` screens to recreate each faithfully, appending to `_data/wiki.yml` as they go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz2VgwLGJfFbNdCRuFSJwx)_